### PR TITLE
Added 7 checks and restructure the code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vscode/settings.json

--- a/WindowsAssessment.ps1
+++ b/WindowsAssessment.ps1
@@ -1533,7 +1533,20 @@ try
 }
 catch
 {
-    writeToScreen -str "All Done! Please ZIP all the files and send it back." -ForegroundColor Green
+    try{
+        $fullPath = Get-Location
+        $fullPath = $fullPath.path
+        $fullPath += "\"+$folderLocation
+        $zipLocation = $fullPath+".zip"
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+        [System.IO.Compression.ZipFile]::CreateFromDirectory($fullPath,$zipLocation)
+        Remove-Item -Recurse -Force -Path $hostname -ErrorAction SilentlyContinue
+        writeToScreen -str "All Done! Please send the output ZIP file." -ForegroundColor Green
+    }
+    catch{
+        writeToScreen -str "All Done! Please ZIP all the files and send it back." -ForegroundColor Green
+        writeToLog -str "Unknown error faild to zip folder"
+    }
 }
 
 $endTime = Get-Date

--- a/WindowsAssessment.ps1
+++ b/WindowsAssessment.ps1
@@ -1,7 +1,7 @@
 param ([Switch]$EnableSensitiveInfoSearch = $false)
 # add the "EnableSensitiveInfoSearch" flag to search for sensitive data
 
-$Version = "1.20" # used for logging purposes
+$Version = "1.21" # used for logging purposes
 ###########################################################
 <# TODO:
 - Output the results to a single file with a simple table
@@ -42,7 +42,6 @@ $Version = "1.20" # used for logging purposes
 - Log the time of each operation to the log file (create a function for it and reuse)
 - Run the script from remote location to a list of servers - psexec, remote ps, etc.
 - Change script structure to functions - Done
-- Zip files without the need for PowerShell 5.0
 ##########################################################
 Controls Checklist:
 - OS is up to date (hotfixes file shows recent updates)
@@ -87,7 +86,7 @@ Controls Checklist:
 - GPO Enforce reprocess check (Domain-Hardning file)
 - Always install with elevated privileges setting (Domain-Hardning file)
 ##########################################################
-@Haim Nachmias
+@Haim Nachmias @Nital Ruzin
 ##########################################################>
 
 ###Genral Vals

--- a/WindowsAssessment.ps1
+++ b/WindowsAssessment.ps1
@@ -108,11 +108,12 @@ function writeToFile {
     )
     if (!(Test-Path "$path\$file"))
     {
-        New-Item -path $path -name $file -type "file" -value $str"`n" | Out-Null
+        New-Item -path $path -name $file -type "file" -value $str | Out-Null
+        writeToFile -path $path -file $file -str""
     }
     else
     {
-        Add-Content -path "$path\$file" -value $str
+        Add-Content -path "$path\$file" -value $str -
     } 
 }
 #function that writes the log file
@@ -143,7 +144,7 @@ function dataWhoAmI {
     $outputFile = getNameForFile -name $name -extention ".txt"
     writeToScreen -str "Running whoami..." -ForegroundColor Yellow
     writeToLog -str "running DataWhoAmI function"
-    writeToFile -file $outputFile -path $folderLocation -str "`Output of `"whoami /all`" command:`n"
+    writeToFile -file $outputFile -path $folderLocation -str "`Output of `"whoami /all`" command:`r`n"
     # when running whoami /all and not connected to the domain, claims information cannot be fetched and an error occurs. Temporarily silencing errors to avoid this.
     #$PrevErrorActionPreference = $ErrorActionPreference
     #$ErrorActionPreference = "SilentlyContinue"
@@ -156,10 +157,10 @@ function dataWhoAmI {
             writeToFile -file $outputFile -path $folderLocation -str (whoami /all)
         }
     #$ErrorActionPreference = $PrevErrorActionPreference
-    writeToFile -file $outputFile -path $folderLocation -str "`n========================================================================================================" 
-    writeToFile -file $outputFile -path $folderLocation -str "`nSome rights allow for local privilege escalation to SYSTEM and shouldn't be granted to non-admin users:"
-    writeToFile -file $outputFile -path $folderLocation -str "`nSeImpersonatePrivilege`nSeAssignPrimaryPrivilege`nSeTcbPrivilege`nSeBackupPrivilege`nSeRestorePrivilege`nSeCreateTokenPrivilege`nSeLoadDriverPrivilege`nSeTakeOwnershipPrivilege`nSeDebugPrivilege " 
-    writeToFile -file $outputFile -path $folderLocation -str "`nSee the following guide for more info:`nhttps://book.hacktricks.xyz/windows/windows-local-privilege-escalation/privilege-escalation-abusing-tokens"
+    writeToFile -file $outputFile -path $folderLocation -str "`r`n========================================================================================================" 
+    writeToFile -file $outputFile -path $folderLocation -str "`r`nSome rights allow for local privilege escalation to SYSTEM and shouldn't be granted to non-admin users:"
+    writeToFile -file $outputFile -path $folderLocation -str "`r`nSeImpersonatePrivilege `r`nSeAssignPrimaryPrivilege `r`nSeTcbPrivilege `r`nSeBackupPrivilege `r`nSeRestorePrivilege `r`nSeCreateTokenPrivilege `r`nSeLoadDriverPrivilege `r`nSeTakeOwnershipPrivilege `r`nSeDebugPrivilege " 
+    writeToFile -file $outputFile -path $folderLocation -str "`r`nSee the following guide for more info:`r`nhttps://book.hacktricks.xyz/windows/windows-local-privilege-escalation/privilege-escalation-abusing-tokens"
 }
 
 # get IP settings
@@ -170,7 +171,7 @@ function dataIpSettings {
     $outputFile = getNameForFile -name $name -extention ".txt"
     writeToScreen -str "Running ipconfig..." -ForegroundColor Yellow
     writeToLog -str "running DataIpSettings function"
-    writeToFile -file $outputFile -path $folderLocation -str "`Output of `"ipconfig /all`" command:`n" 
+    writeToFile -file $outputFile -path $folderLocation -str "`Output of `"ipconfig /all`" command:`r`n" 
     writeToFile -file $outputFile -path $folderLocation -str (ipconfig /all) 
 }
 
@@ -341,7 +342,7 @@ function dataInstalledHotfixes {
     writeToFile -file $outputFile -path $folderLocation -str "https://en.wikipedia.org/wiki/List_of_Microsoft_Windows_versions" 
     writeToFile -file $outputFile -path $folderLocation -str "https://en.wikipedia.org/wiki/Windows_10_version_history" 
     writeToFile -file $outputFile -path $folderLocation -str "https://support.microsoft.com/he-il/help/13853/windows-lifecycle-fact-sheet" 
-    writeToFile -file $outputFile -path $folderLocation -str "Output of `"Get-HotFix`" PowerShell command, sorted by installation date:`n" 
+    writeToFile -file $outputFile -path $folderLocation -str "Output of `"Get-HotFix`" PowerShell command, sorted by installation date:`r`n" 
     writeToFile -file $outputFile -path $folderLocation -str (Get-HotFix | Sort-Object InstalledOn -Descending -ErrorAction SilentlyContinue )
     <# wmic qfe list full /format:$htable > $hostname\hotfixes_$hostname.html
     if ((Get-Content $hostname\hotfixes_$hostname.html) -eq $null)
@@ -361,7 +362,7 @@ function dataRunningProcess {
     writeToLog -str "running dataRunningProcess function"
     $outputFile = getNameForFile -name $name -extention ".txt"
     writeToScreen -str "Getting processes..." -ForegroundColor Yellow
-    writeToFile -file $outputFile -path $folderLocation -str  "Output of `"Get-Process`" PowerShell command:`n"
+    writeToFile -file $outputFile -path $folderLocation -str  "Output of `"Get-Process`" PowerShell command:`r`n"
     try {
         writeToFile -file $outputFile -path $folderLocation -str (Get-Process -IncludeUserName | Format-Table -AutoSize ProcessName, id, company, ProductVersion, username, cpu, WorkingSet | Out-String -Width 180 | Out-String) 
     }
@@ -380,7 +381,7 @@ function dataServices {
     writeToLog -str "running dataServices function"
     $outputFile = getNameForFile -name $name -extention ".txt"
     writeToScreen -str "Getting services..." -ForegroundColor Yellow
-    writeToFile -file $outputFile -path $folderLocation -str "Output of `"Get-WmiObject win32_service`" PowerShell command:`n"
+    writeToFile -file $outputFile -path $folderLocation -str "Output of `"Get-WmiObject win32_service`" PowerShell command:`r`n"
     writeToFile -file $outputFile -path $folderLocation -str (Get-WmiObject win32_service  | Sort-Object displayname | Format-Table -AutoSize DisplayName, Name, State, StartMode, StartName | Out-String -Width 180 | Out-String)
 }
 
@@ -426,7 +427,7 @@ function dataSharedFolders{
                 {
                 # Unfortunately, some of the shares security settings are missing from the WMI. Complicated stuff. Google "Count of shares != Count of share security"
                 writeToLog -str "Function dataSharedFolders:Couldn't find share permissions, doesn't exist in WMI Win32_LogicalShareSecuritySetting."
-                writeToFile -file $outputFile -path $folderLocation -str "Couldn't find share permissions, doesn't exist in WMI Win32_LogicalShareSecuritySetting.`n" }
+                writeToFile -file $outputFile -path $folderLocation -str "Couldn't find share permissions, doesn't exist in WMI Win32_LogicalShareSecuritySetting.`r`n" }
             else
             {
                 $DACLs = (Get-WmiObject -Class Win32_LogicalShareSecuritySetting -Filter "Name='$shareName'" -ErrorAction SilentlyContinue).GetSecurityDescriptor().Descriptor.DACL
@@ -457,7 +458,7 @@ function dataAccountPolicy {
     $outputFile = getNameForFile -name $name -extention ".txt"
     writeToScreen -str "Getting local and domain account policy..." -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str "============= Local Account Policy ============="
-    writeToFile -file $outputFile -path $folderLocation -str "Output of `"NET ACCOUNTS`" command:`n"
+    writeToFile -file $outputFile -path $folderLocation -str "Output of `"NET ACCOUNTS`" command:`r`n"
     writeToFile -file $outputFile -path $folderLocation -str (NET ACCOUNTS)
     # check if the computer is in a domain
     writeToFile -file $outputFile -path $folderLocation -str "============= Domain Account Policy ============="
@@ -465,7 +466,7 @@ function dataAccountPolicy {
     {
         if (((Get-WmiObject -Class Win32_OperatingSystem).ProductType -eq 2) -or (Test-ComputerSecureChannel))
         {
-            writeToFile -file $outputFile -path $folderLocation -str "Output of `"NET ACCOUNTS /domain`" command:`n" 
+            writeToFile -file $outputFile -path $folderLocation -str "Output of `"NET ACCOUNTS /domain`" command:`r`n" 
             writeToFile -file $outputFile -path $folderLocation -str (NET ACCOUNTS /domain) 
         }    
         else
@@ -493,20 +494,20 @@ function dataLocalUsers {
     {
         writeToScreen -str "Getting local users + administrators..." -ForegroundColor Yellow
         writeToFile -file $outputFile -path $folderLocation -str "============= Local Administrators ============="
-        writeToFile -file $outputFile -path $folderLocation -str "Output of `"NET LOCALGROUP administrators`" command:`n"
+        writeToFile -file $outputFile -path $folderLocation -str "Output of `"NET LOCALGROUP administrators`" command:`r`n"
         writeToFile -file $outputFile -path $folderLocation -str (NET LOCALGROUP administrators)
         writeToFile -file $outputFile -path $folderLocation -str "============= Local Users ============="
         # Get-LocalUser exists only in Windows 10 / 2016
         try
         {
-            writeToFile -file $outputFile -path $folderLocation -str "Output of `"Get-LocalUser`" PowerShell command:`n" 
+            writeToFile -file $outputFile -path $folderLocation -str "Output of `"Get-LocalUser`" PowerShell command:`r`n" 
             writeToFile -file $outputFile -path $folderLocation -str (Get-LocalUser | Format-Table name, enabled, AccountExpires, PasswordExpires, PasswordRequired, PasswordLastSet, LastLogon, description, SID | Out-String -Width 180 | Out-String)
         }
         catch
         {
             if($psVer -ge 3){
-                writeToFile -file $outputFile -path $folderLocation -str "Getting information regarding local users from WMI.`n"
-                writeToFile -file $outputFile -path $folderLocation -str "Output of `"Get-CimInstance win32_useraccount -Namespace `"root\cimv2`" -Filter `"LocalAccount=`'$True`'`"`" PowerShell command:`n"
+                writeToFile -file $outputFile -path $folderLocation -str "Getting information regarding local users from WMI.`r`n"
+                writeToFile -file $outputFile -path $folderLocation -str "Output of `"Get-CimInstance win32_useraccount -Namespace `"root\cimv2`" -Filter `"LocalAccount=`'$True`'`"`" PowerShell command:`r`n"
                 writeToFile -file $outputFile -path $folderLocation -str (Get-CimInstance win32_useraccount -Namespace "root\cimv2" -Filter "LocalAccount='$True'" | Select-Object Caption,Disabled,Lockout,PasswordExpires,PasswordRequired,Description,SID | format-table -autosize | Out-String -Width 180 | Out-String)
             }
             else{
@@ -687,7 +688,7 @@ function dataRDPSecuirty {
         writeToFile -file $outputFile -path $folderLocation -str "MaxDisconnectionTime = Time limit for disconnected RDP sessions" 
         writeToFile -file $outputFile -path $folderLocation -str "fResetBroken = Log off session (instead of disconnect) when time limits are reached" 
         writeToFile -file $outputFile -path $folderLocation -str "60000 = 1 minute, 3600000 = 1 hour, etc."
-        writeToFile -file $outputFile -path $folderLocation -str "`nFor further information, see the GPO settings at: Computer Configuration\Administrative Templates\Windows Components\Remote Desktop Services\Remote Desktop Session\Session Time Limits"
+        writeToFile -file $outputFile -path $folderLocation -str "`r`nFor further information, see the GPO settings at: Computer Configuration\Administrative Templates\Windows Components\Remote Desktop Services\Remote Desktop Session\Session Time Limits"
     } 
 }
 
@@ -727,6 +728,9 @@ function dataCredentialGuard {
         writeToFile -file $outputFile -path $folderLocation -str "============= Raw Device Guard Settings from Get-ComputerInfo ============="
         writeToFile -file $outputFile -path $folderLocation -str ($DevGuardPS | Out-String)
     }
+    else{
+        writeToLog -str "Function dataCredentialGuard: not supported OS no check is needed..."
+    }
     
 }
 
@@ -751,6 +755,9 @@ function dataLSAProtectionConf {
             else
                 {writeToFile -file $outputFile -path $folderLocation -str "LSA protection is off. Which is bad and a possible finding."}
         }
+    }
+    else{
+        writeToLog -str "Function dataLSAProtectionConf: not supported OS no check is needed"
     }
     
 }
@@ -808,14 +815,14 @@ function checkAntiVirusStatus {
             $AntiVirusProducts = Get-WmiObject -Namespace root\SecurityCenter2 -Class AntiVirusProduct
             $FirewallProducts = Get-WmiObject -Namespace root\SecurityCenter2 -Class FirewallProduct
             $AntiSpywareProducts = Get-WmiObject -Namespace root\SecurityCenter2 -Class AntiSpywareProduct
-            writeToFile -file $outputFile -path $folderLocation -str "Security products status was taken from WMI values on WMI namespace `"root\SecurityCenter2`".`n"
+            writeToFile -file $outputFile -path $folderLocation -str "Security products status was taken from WMI values on WMI namespace `"root\SecurityCenter2`".`r`n"
         }
         else
         {
             $AntiVirusProducts = Get-WmiObject -Namespace root\SecurityCenter -Class AntiVirusProduct
             $FirewallProducts = Get-WmiObject -Namespace root\SecurityCenter -Class FirewallProduct
             $AntiSpywareProducts = Get-WmiObject -Namespace root\SecurityCenter -Class AntiSpywareProduct
-            writeToFile -file $outputFile -path $folderLocation -str "Security products status was taken from WMI values on WMI namespace `"root\SecurityCenter`".`n"
+            writeToFile -file $outputFile -path $folderLocation -str "Security products status was taken from WMI values on WMI namespace `"root\SecurityCenter`".`r`n"
         }
         if ($null -eq $AntiVirusProducts)
             {writeToFile -file $outputFile -path $folderLocation -str "No Anti Virus products were found."}
@@ -844,7 +851,7 @@ function checkAntiVirusStatus {
         writeToFile -file $outputFile -path $folderLocation -str "============= Anti-Spyware Products Status (Raw Data) =============" 
         writeToFile -file $outputFile -path $folderLocation -str ($AntiSpywareProducts | Out-String)
         # check Windows Defender settings
-        writeToFile -file $outputFile -path $folderLocation -str "============= Windows Defender Settings Status =============`n"
+        writeToFile -file $outputFile -path $folderLocation -str "============= Windows Defender Settings Status =============`r`n"
         $WinDefenderSettings = Get-ItemProperty "HKLM:\SOFTWARE\Policies\Microsoft\Windows Defender\Policy Manager"
         switch ($WinDefenderSettings.AllowRealtimeMonitoring)
         {
@@ -898,10 +905,10 @@ function dataWinFirewall {
         # The NetFirewall commands are supported from Windows 8/2012 (version 6.2) and powershell is 4 and above
         if ($psVer -ge 4 -and (($winVersion.Major -gt 6) -or (($winVersion.Major -eq 6) -and ($winVersion.Minor -ge 2)))) # version should be 6.2+
         { 
-            writeToFile -file $outputFile -path $folderLocation -str "----------------------------------`n"
+            writeToFile -file $outputFile -path $folderLocation -str "----------------------------------`r`n"
             writeToFile -file $outputFile -path $folderLocation -str "The output of Get-NetFirewallProfile is:"
-            writeToFile -file $outputFile -path $folderLocation -str Get-NetFirewallProfile -PolicyStore ActiveStore | Out-String   
-            writeToFile -file $outputFile -path $folderLocation -str "----------------------------------`n"
+            writeToFile -file $outputFile -path $folderLocation -str (Get-NetFirewallProfile -PolicyStore ActiveStore | Out-String)   
+            writeToFile -file $outputFile -path $folderLocation -str "----------------------------------`r`n"
             writeToFile -file $outputFile -path $folderLocation -str "The output of Get-NetFirewallRule can be found in the Windows-Firewall-Rules CSV file. No port and IP information there."
             $temp = $folderLocation + "\" + (getNameForFile -name $name -extention ".csv")
             #Get-NetFirewallRule -PolicyStore ActiveStore | Export-Csv $temp -NoTypeInformation - removed replaced by Nir's Offer
@@ -921,7 +928,7 @@ function dataWinFirewall {
         }
         if ($runningAsAdmin)
         {
-            writeToFile -file $outputFile -path $folderLocation -str "----------------------------------`n"
+            writeToFile -file $outputFile -path $folderLocation -str "----------------------------------`r`n"
             writeToLog -str "Function dataWinFirewall: Exporting to wfw" 
             $temp = $folderLocation + "\" + (getNameForFile -name $name -extention ".wfw")
             netsh advfirewall export $temp | Out-Null
@@ -954,7 +961,7 @@ function checkLLMNRAndNetBIOS {
     else
         {writeToFile -file $outputFile -path $folderLocation -str "LLMNR is enabled, which is a finding, especially for workstations."}
         writeToFile -file $outputFile -path $folderLocation -str "============= NETBIOS Name Service Configuration ============="
-        writeToFile -file $outputFile -path $folderLocation -str "Checking the NETBIOS Node Type configuration - see 'https://getadmx.com/?Category=KB160177#' for details...`n"
+        writeToFile -file $outputFile -path $folderLocation -str "Checking the NETBIOS Node Type configuration - see 'https://getadmx.com/?Category=KB160177#' for details...`r`n"
     $NodeType = (Get-ItemProperty "HKLM:\System\CurrentControlSet\Services\NetBT\Parameters" NodeType -ErrorAction SilentlyContinue).NodeType
     if ($NodeType -eq 2)
         {writeToFile -file $outputFile -path $folderLocation -str "NetBIOS Node Type is set to P-node (only point-to-point name queries to a WINS name server), which is secure."}
@@ -970,7 +977,7 @@ function checkLLMNRAndNetBIOS {
 
         writeToFile -file $outputFile -path $folderLocation -str "Checking the NETBIOS over TCP/IP configuration for each network interface."
         writeToFile -file $outputFile -path $folderLocation -str "Network interface properties -> IPv4 properties -> Advanced -> WINS -> NetBIOS setting"
-        writeToFile -file $outputFile -path $folderLocation -str "`nNetbiosOptions=0 is default, and usually means enabled, which is not secure and a possible finding."
+        writeToFile -file $outputFile -path $folderLocation -str "`r`nNetbiosOptions=0 is default, and usually means enabled, which is not secure and a possible finding."
         writeToFile -file $outputFile -path $folderLocation -str "NetbiosOptions=1 is enabled, which is not secure and a possible finding."
         writeToFile -file $outputFile -path $folderLocation -str "NetbiosOptions=2 is disabled, which is secure."
         writeToFile -file $outputFile -path $folderLocation -str "If NetbiosOptions is set to 2 for the main interface, NetBIOS Name Service is protected against poisoning attacks even though the NodeType is not set to P-node, and this is not a finding."
@@ -1042,7 +1049,7 @@ function checkNetSessionEnum {
     writeToFile -file $outputFile -path $folderLocation -str "--------- Security Descriptor Check ---------"
     # copied from Get-NetSessionEnumPermission
     writeToFile -file $outputFile -path $folderLocation -str "Below are the permissions granted to enumerate net sessions."
-    writeToFile -file $outputFile -path $folderLocation -str "If the Authenticated Users group has permissions, this is a finding.`n"
+    writeToFile -file $outputFile -path $folderLocation -str "If the Authenticated Users group has permissions, this is a finding.`r`n"
     $SessionRegValue = (Get-ItemProperty HKLM:\SYSTEM\CurrentControlSet\Services\LanmanServer\DefaultSecurity SrvsvcSessionInfo).SrvsvcSessionInfo
     $SecurityDesc = New-Object -TypeName System.Security.AccessControl.CommonSecurityDescriptor -ArgumentList ($true,$false,$SessionRegValue,0)
     writeToFile -file $outputFile -path $folderLocation -str ($SecurityDesc.DiscretionaryAcl | ForEach-Object {$_ | Add-Member -MemberType ScriptProperty -Name TranslatedSID -Value ({$this.SecurityIdentifier.Translate([System.Security.Principal.NTAccount]).Value}) -PassThru} | Out-String)
@@ -1051,7 +1058,7 @@ function checkNetSessionEnum {
     writeToFile -file $outputFile -path $folderLocation -str "Default value for Windows 2019 and newer builds of Windows 10 (hardened): 1,0,4,128,160,0,0,0,172"
     writeToFile -file $outputFile -path $folderLocation -str "Default value for Windows 2016, older builds of Windows 10 and older OS versions (not secure - finding): 1,0,4,128,120,0,0,0,132"
     writeToFile -file $outputFile -path $folderLocation -str "Value after running NetCease (hardened): 1,0,4,128,20,0,0,0,32"
-    writeToFile -file $outputFile -path $folderLocation -str "`nThe SrvsvcSessionInfo registry value under HKLM:\SYSTEM\CurrentControlSet\Services\LanmanServer\DefaultSecurity is set to:"
+    writeToFile -file $outputFile -path $folderLocation -str "`r`nThe SrvsvcSessionInfo registry value under HKLM:\SYSTEM\CurrentControlSet\Services\LanmanServer\DefaultSecurity is set to:"
     writeToFile -file $outputFile -path $folderLocation -str ($SessionRegValue | Out-String)
 }
 
@@ -1064,14 +1071,14 @@ function checkSAMEnum{
     writeToLog -str "running checkSAMEnum function"
     writeToScreen -str "Getting SAM enumeration configuration..." -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str "============= Remote SAM (SAMR) Configuration ============="
-    writeToFile -file $outputFile -path $folderLocation -str "`nBy default, in Windows 2016 (and above) and Windows 10 build 1607 (and above), only Administrators are allowed to make remote calls to SAM with the SAMRPC protocols, and (among other things) enumerate the members of the local groups."
+    writeToFile -file $outputFile -path $folderLocation -str "`r`nBy default, in Windows 2016 (and above) and Windows 10 build 1607 (and above), only Administrators are allowed to make remote calls to SAM with the SAMRPC protocols, and (among other things) enumerate the members of the local groups."
     writeToFile -file $outputFile -path $folderLocation -str "However, in older OS versions, low privileged domain users can also query the SAM with SAMRPC, which is a major vulnerability mainly on non-Domain Contollers, enabling valuable reconnaissance, as leveraged by BloodHound."
     writeToFile -file $outputFile -path $folderLocation -str "These old OS versions (Windows 7/2008R2 and above) can be hardened by installing a KB and configuring only the Local Administrators group in the following GPO policy: 'Network access: Restrict clients allowed to make remote calls to SAM'."
     writeToFile -file $outputFile -path $folderLocation -str "The newer OS versions are also recommended to be configured with the policy, though it is not essential."
-    writeToFile -file $outputFile -path $folderLocation -str "`nSee more details here:"
+    writeToFile -file $outputFile -path $folderLocation -str "`r`nSee more details here:"
     writeToFile -file $outputFile -path $folderLocation -str "https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/network-access-restrict-clients-allowed-to-make-remote-sam-calls"
     writeToFile -file $outputFile -path $folderLocation -str "https://blog.stealthbits.com/making-internal-reconnaissance-harder-using-netcease-and-samri1o"
-    writeToFile -file $outputFile -path $folderLocation -str "`n----------------------------------------------------"
+    writeToFile -file $outputFile -path $folderLocation -str "`r`n----------------------------------------------------"
 
     $RestrictRemoteSAM = Get-ItemProperty HKLM:\SYSTEM\CurrentControlSet\Control\Lsa RestrictRemoteSAM -ErrorAction SilentlyContinue
     if ($null -eq $RestrictRemoteSAM)
@@ -1188,19 +1195,19 @@ function checkNTLMv2 {
     writeToFile -file $outputFile -path $folderLocation -str "============= NTLM Check ============="
     writeToFile -file $outputFile -path $folderLocation -str "NTLMv1 & LM are  legacy authentication protocols that are reversible"
     writeToFile -file $outputFile -path $folderLocation -str "If there are legacy systems in the network configure Level 3 NTLM hardning on the domain (that way only the lagacy system will use the legacy authentication) otherwise select Level 5"
-    writeToFile -file $outputFile -path $folderLocation -str "For more information go to: https://docs.microsoft.com/en-us/troubleshoot/windows-client/windows-security/enable-ntlm-2-authentication `n"
+    writeToFile -file $outputFile -path $folderLocation -str "For more information go to: https://docs.microsoft.com/en-us/troubleshoot/windows-client/windows-security/enable-ntlm-2-authentication `r`n"
     $temp = Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Lsa" -Name LmCompatibilityLevel -ErrorAction SilentlyContinue # registry key that contains the NTLM restrications
     if($null -eq $temp){
-        writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authntication setting: (Level Unknown) LM and NTLMv1 restriction does not exist - using OS default`n" #using system default depends on OS version
+        writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authntication setting: (Level Unknown) LM and NTLMv1 restriction does not exist - using OS default`r`n" #using system default depends on OS version
     }
     switch ($temp.lmcompatibilitylevel) {
-        (0) { writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authntication setting: (Level 0) Send LM and NTLM response; never use NTLM 2 session security. Clients use LM and NTLM authentication, and never use NTLM 2 session security; domain controllers accept LM, NTLM, and NTLM 2 authentication. - this is a finding!`n" }
-        (1) { writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authntication setting: (Level 1) Use NTLM 2 session security if negotiated. Clients use LM and NTLM authentication, and use NTLM 2 session security if the server supports it; domain controllers accept LM, NTLM, and NTLM 2 authentication. - this is a finding!`n" }
-        (2) { writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authntication setting: (Level 2) Send NTLM response only. Clients use only NTLM authentication, and use NTLM 2 session security if the server supports it; domain controllers accept LM, NTLM, and NTLM 2 authentication. - this is a finding!`n" }
-        (3) { writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authntication setting: (Level 3) Send NTLM 2 response only. Clients use NTLM 2 authentication, and use NTLM 2 session security if the server supports it; domain controllers accept LM, NTLM, and NTLM 2 authentication. - Not a finding if all servers are with the same configuration`n"}
-        (4) { writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authntication setting: (Level 4) Domain controllers refuse LM responses. Clients use NTLM authentication, and use NTLM 2 session security if the server supports it; domain controllers refuse LM authentication (that is, they accept NTLM and NTLM 2) - Not a finding if all servers are with the same configuration`n"}
-        (5) { writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authntication setting: (Level 5) Domain controllers refuse LM and NTLM responses (accept only NTLM 2). Clients use NTLM 2 authentication, use NTLM 2 session security if the server supports it; domain controllers refuse NTLM and LM authentication (they accept only NTLM 2 - A good thing!)`n"}
-        Default {writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authntication setting: (Level Unknown) - " + $temp.lmcompatibilitylevel + "`n"}
+        (0) { writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authntication setting: (Level 0) Send LM and NTLM response; never use NTLM 2 session security. Clients use LM and NTLM authentication, and never use NTLM 2 session security; domain controllers accept LM, NTLM, and NTLM 2 authentication. - this is a finding!`r`n" }
+        (1) { writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authntication setting: (Level 1) Use NTLM 2 session security if negotiated. Clients use LM and NTLM authentication, and use NTLM 2 session security if the server supports it; domain controllers accept LM, NTLM, and NTLM 2 authentication. - this is a finding!`r`n" }
+        (2) { writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authntication setting: (Level 2) Send NTLM response only. Clients use only NTLM authentication, and use NTLM 2 session security if the server supports it; domain controllers accept LM, NTLM, and NTLM 2 authentication. - this is a finding!`r`n" }
+        (3) { writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authntication setting: (Level 3) Send NTLM 2 response only. Clients use NTLM 2 authentication, and use NTLM 2 session security if the server supports it; domain controllers accept LM, NTLM, and NTLM 2 authentication. - Not a finding if all servers are with the same configuration`r`n"}
+        (4) { writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authntication setting: (Level 4) Domain controllers refuse LM responses. Clients use NTLM authentication, and use NTLM 2 session security if the server supports it; domain controllers refuse LM authentication (that is, they accept NTLM and NTLM 2) - Not a finding if all servers are with the same configuration`r`n"}
+        (5) { writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authntication setting: (Level 5) Domain controllers refuse LM and NTLM responses (accept only NTLM 2). Clients use NTLM 2 authentication, use NTLM 2 session security if the server supports it; domain controllers refuse NTLM and LM authentication (they accept only NTLM 2 - A good thing!)`r`n"}
+        Default {writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authntication setting: (Level Unknown) - " + $temp.lmcompatibilitylevel + "`r`n"}
     }
 }
 
@@ -1212,9 +1219,9 @@ function checkGPOReprocess {
     $outputFile = getNameForFile -name $name -extention ".txt"
     writeToLog -str "running checkGPOReprocess function"
     writeToScreen -str "Getting GPO enforcment..." -ForegroundColor Yellow
-    writeToFile -file $outputFile -path $folderLocation -str "`n============= GPO Reprocess Check ============="
+    writeToFile -file $outputFile -path $folderLocation -str "`r`n============= GPO Reprocess Check ============="
     writeToFile -file $outputFile -path $folderLocation -str "If GPO reprocess is not enforced once the GPO received is the first and lest time the gpo is enforced (until next change)"
-    writeToFile -file $outputFile -path $folderLocation -str "GPO can be overridden with administrator premission - it is recommended that all security settings will be repossessed every time the system checks for GPO change`n"
+    writeToFile -file $outputFile -path $folderLocation -str "GPO can be overridden with administrator premission - it is recommended that all security settings will be repossessed every time the system checks for GPO change`r`n"
     $temp = Get-ItemProperty -Path "HKLM:\Software\Policies\Microsoft\Windows\Group Policy\{35378EAC-683F-11D2-A89A-00C04FBBCFA2}" -Name NoGPOListChanges -ErrorAction SilentlyContinue # registry that contains registry polciy reprocess settings 
     if($null -eq $temp){
         writeToFile -file $outputFile -path $folderLocation -str ' > GPO regirstry policy reprocess is not configured "processed even if not changed"' 
@@ -1247,8 +1254,8 @@ function checkInstallElevated {
     $outputFile = getNameForFile -name $name -extention ".txt"
     writeToLog -str "running checkInstallElevated function"
     writeToScreen -str "Getting Always install with elevation setting..." -ForegroundColor Yellow
-    writeToFile -file $outputFile -path $folderLocation -str "`n============= Always install elevated Check ============="
-    writeToFile -file $outputFile -path $folderLocation -str "checking if GPO is configured to force installation as administrator - can be used by an attacker`n"
+    writeToFile -file $outputFile -path $folderLocation -str "`r`n============= Always install elevated Check ============="
+    writeToFile -file $outputFile -path $folderLocation -str "checking if GPO is configured to force installation as administrator - can be used by an attacker`r`n"
     $temp = Get-ItemProperty -Path "HKLM:\Software\Policies\Microsoft\Windows\Installer" -Name AlwaysInstallElevated -ErrorAction SilentlyContinue
     if($null -eq $temp){
         writeToFile -file $outputFile -path $folderLocation -str ' > No GPO for for "Always install with elevation"'
@@ -1270,12 +1277,12 @@ function checkPowrshellAudit {
     $outputFile = getNameForFile -name $name -extention ".txt"
     writeToLog -str "running checkPowrshellAudit function"
     writeToScreen -str "Getting Powershell audit policy..." -ForegroundColor Yellow
-    writeToFile -file $outputFile -path $folderLocation -str "`n============= PowerShell Audit ============="
+    writeToFile -file $outputFile -path $folderLocation -str "`r`n============= PowerShell Audit ============="
     writeToFile -file $outputFile -path $folderLocation -str " Powershell Audit is configured by three main settings modules, script block and transcript:"
     writeToFile -file $outputFile -path $folderLocation -str "  - Model logging - audits the modules used in powershell commands\scripts"
     writeToFile -file $outputFile -path $folderLocation -str "  - Script block - audits the use of script block in powershell commands\scripts"
     writeToFile -file $outputFile -path $folderLocation -str "  - Transcript - audits the commands running in powershell"
-    writeToFile -file $outputFile -path $folderLocation -str " For comprehensive audit trail all of those need to be configured and each of them has a special setting that need to be configured to work properly (for example in module audit you need to specify witch modules to audit)`n"
+    writeToFile -file $outputFile -path $folderLocation -str " For comprehensive audit trail all of those need to be configured and each of them has a special setting that need to be configured to work properly (for example in module audit you need to specify witch modules to audit)`r`n"
     # --- Start Of Module Logging ---
     writeToFile -file $outputFile -path $folderLocation -str "--- PowerShell Module audit: "
     $temp = Get-ItemProperty -Path "HKLM:\Software\Policies\Microsoft\Windows\PowerShell\ModuleLogging" -Name EnableModuleLogging -ErrorAction SilentlyContinue # registry that checks Module Logging in Computer-Space
@@ -1409,7 +1416,7 @@ function dataSystemInfo {
         writeToFile -file $outputFile -path $folderLocation -str "============= Get-ComputerInfo =============" 
         writeToFile -file $outputFile -path $folderLocation -str (Get-ComputerInfo | Out-String)
     }
-    writeToFile -file $outputFile -path $folderLocation -str "`n============= systeminfo ============="
+    writeToFile -file $outputFile -path $folderLocation -str "`r`n============= systeminfo ============="
     writeToFile -file $outputFile -path $folderLocation -str (systeminfo | Out-String)
 }
 
@@ -1421,7 +1428,7 @@ function dataAuditPolicy {
     $outputFile = getNameForFile -name $name -extention ".txt"
     writeToLog -str "running dataAuditSettings function"
     writeToScreen -str "getting audit policy settings..." -ForegroundColor Yellow
-    writeToFile -file $outputFile -path $folderLocation -str "`n============= Audit Policy Configuration ============="
+    writeToFile -file $outputFile -path $folderLocation -str "`r`n============= Audit Policy Configuration ============="
     if ($winVersion.Major -ge 6)
     {
         if($runningAsAdmin)
@@ -1440,8 +1447,7 @@ function checkCommandLineAudit {
     $outputFile = getNameForFile -name $name -extention ".txt"
     writeToLog -str "running checkCommandLineAudit function"
     writeToScreen -str "checking command line audit..." -ForegroundColor Yellow
-    writeToFile -file $outputFile -path $folderLocation -str "`n============= Command line Audit ============="
-    writeToFile -file $outputFile -path $folderLocation -str ""
+    writeToFile -file $outputFile -path $folderLocation -str "`r`n============= Command line Audit ============="
     writeToFile -file $outputFile -path $folderLocation -str "Command line Audit tracks all commands running in the CLI"
     writeToFile -file $outputFile -path $folderLocation -str "Supported windows is 8/2012R2 and above"
 

--- a/WindowsAssessment.ps1
+++ b/WindowsAssessment.ps1
@@ -1,16 +1,14 @@
 param ([Switch]$EnableSensitiveInfoSearch = $false)
 # add the "EnableSensitiveInfoSearch" flag to search for sensitive data
 
-$Version = "1.21" # used for logging purposes
+$Version = "1.22" # used for logging purposes
 ###########################################################
 <# TODO:
 - Output the results to a single file with a simple table
 - Add OS version into the output file name (for example, "SERVERNAME_Win2008R2")
 - Add AD permissions checks from here: https://github.com/haim-n/ADDomainDaclAnalysis
 - Check for bugs in the SMB1 check - fixed need to check
-- Log errors to a log file using Start/Stop-Transcript - PSv5 only 
 - Debug the FirewallProducts check
-- Check for Windows Update / WSUS settings, check for WSUS over HTTP (reg key)
 - Update PSv2 checks - speak with Nir/Liran, use this: https://robwillis.info/2020/01/disabling-powershell-v2-with-group-policy/, https://github.com/robwillisinfo/Disable-PSv2/blob/master/Disable-PSv2.ps1
 - Debug the RDP check on multiple OS versions
 - Integrate more checks from https://adsecurity.org/?p=3299
@@ -21,7 +19,6 @@ $Version = "1.21" # used for logging purposes
 -- Determine if the local administrators group is configured as a restricted group with fixed members (based on Security-Policy inf file)
 -- Determine if Domain Admins cannot login to lower tier computers (Security-Policy inf file: Deny log on locally/remote/service/batch)
 - Determine if computer is protected against IPv6 based DNS spoofing (mitm6) - IPv6 disabled (Get-NetAdapterBinding -ComponentID ms_tcpip6) or inbound ICMPv6 / outbound DHCPv6 blocked by FW
-- Add WPAD check
 - Test on Windows 2008
 - Check AV/Defender configuration also on non-Windows 10
 - Move lists to CSV format instead of TXT
@@ -81,6 +78,9 @@ Controls Checklist:
 - GPO Enforce reprocess check (Domain-Hardening file)
 - Always install with elevated privileges setting (Domain-Hardening file)
 - Check if external DNS servers (8.8.8.8, etc.) are accessible (Internet-Connectivity file)
+- Log errors to a log file using Start/Stop-Transcript (ScriptTranscript file)
+- Check for Windows Update / WSUS settings, check for WSUS over HTTP (Domain hardening file)
+- WPAD and proxy configuration check (Internet-Connectivity file)
 ##########################################################
 @Haim Nachmias @Nital Ruzin
 ##########################################################>
@@ -2091,6 +2091,7 @@ checkInstallElevated -name "Domain-Hardening"
 #Check if safe mode access by non-admins is blocked
 checkSafeModeAcc4NonAdmin -name "Domain-Hardening"
 
+#Check Windows update configuration
 checkWinUpdateConfig -name "Domain-Hardening"
 
 # get various system info (can take a few seconds)

--- a/WindowsAssessment.ps1
+++ b/WindowsAssessment.ps1
@@ -144,7 +144,7 @@ function dataWhoAmI {
     # when running whoami /all and not connected to the domain, claims information cannot be fetched and an error occurs. Temporarily silencing errors to avoid this.
     #$PrevErrorActionPreference = $ErrorActionPreference
     #$ErrorActionPreference = "SilentlyContinue"
-    if ((Get-WmiObject -Class Win32_OperatingSystem).ProductType -ne 2){
+    if ((Get-WmiObject -Class Win32_OperatingSystem).ProductType -ne 2 -and (Get-WmiObject -Class Win32_ComputerSystem).PartOfDomain){
         $tmp = Test-ComputerSecureChannel -ErrorAction SilentlyContinue
     }
     else{
@@ -1010,14 +1010,16 @@ function checkAntiVirusStatus {
         $MpPreference = Get-MpPreference
         writeToFile -file $outputFile -path $folderLocation -str ($MpPreference | Out-String)
         writeToFile -file $outputFile -path $folderLocation -str "---------------------------------" 
-        $MpComputerStatus = Get-MpComputerStatus
-        writeToFile -file $outputFile -path $folderLocation -str "Enabled Defender features:" 
-        writeToFile -file $outputFile -path $folderLocation -str ($MpComputerStatus | Format-List *enabled* | Out-String)
-        writeToFile -file $outputFile -path $folderLocation -str "Defender Tamper Protection:"
-        writeToFile -file $outputFile -path $folderLocation -str ($MpComputerStatus | Format-List *tamper* | Out-String)
-        writeToFile -file $outputFile -path $folderLocation -str "Raw output of Get-MpComputerStatus:"
-        writeToFile -file $outputFile -path $folderLocation -str ($MpComputerStatus | Out-String)
-        writeToFile -file $outputFile -path $folderLocation -str "---------------------------------" 
+        $MpComputerStatus = Get-MpComputerStatus -ErrorAction SilentlyContinue
+        if($null -ne $MpComputerStatus){
+            writeToFile -file $outputFile -path $folderLocation -str "Enabled Defender features:" 
+            writeToFile -file $outputFile -path $folderLocation -str ($MpComputerStatus | Format-List *enabled* | Out-String)
+            writeToFile -file $outputFile -path $folderLocation -str "Defender Tamper Protection:"
+            writeToFile -file $outputFile -path $folderLocation -str ($MpComputerStatus | Format-List *tamper* | Out-String)
+            writeToFile -file $outputFile -path $folderLocation -str "Raw output of Get-MpComputerStatus:"
+            writeToFile -file $outputFile -path $folderLocation -str ($MpComputerStatus | Out-String)
+            writeToFile -file $outputFile -path $folderLocation -str "---------------------------------" 
+        }
         writeToFile -file $outputFile -path $folderLocation -str "Attack Surface Reduction Rules Ids:"
         writeToFile -file $outputFile -path $folderLocation -str ($MpPreference.AttackSurfaceReductionRules_Ids | Out-String)
         writeToFile -file $outputFile -path $folderLocation -str "Attack Surface Reduction Rules Actions:"

--- a/WindowsAssessment.ps1
+++ b/WindowsAssessment.ps1
@@ -27,7 +27,6 @@ $Version = "1.21" # used for logging purposes
 - Move lists to CSV format instead of TXT
 - When the script is running by an admin but without UAC, pop an UAC confirmation (https://gallery.technet.microsoft.com/scriptcenter/1b5df952-9e10-470f-ad7c-dc2bdc2ac946)
 - Check Macro and DDE (OLE) settings
-- Check if safe mode access by non-admins is blocked (based on SafeModeBlockNonAdmins reg value) - in work
 - Check if ability to enable mobile hotspot is blocked (GPO Prohibit use of Internet Connection Sharing on your DNS domain network, reg NC_ShowSharedAccessUI)
 - Look for additional checks from windows_hardening.cmd script / Seatbelt
 - Enhance internet connectivity checks (add traceroute, curl to websites over http/s, use proxy configuration, test TCP on few sample ports towards portquiz)

--- a/WindowsAssessment.ps1
+++ b/WindowsAssessment.ps1
@@ -45,7 +45,7 @@ Controls Checklist:
 - Credential guard is running (Credential-Guard file, Win 10/2016 and above)
 - SMB Signing is enforced (SMB file)
 - SMB1 Server is not installed (SMB file)
-- NTLMv2 is enforced  (Domain-Hardning file)
+- NTLMv2 is enforced  (Domain-Hardening file)
 - LLMNR is disabled (LLMNR_and_NETBIOS file)
 - NETBIOS Name Service is disabled (LLMNR_and_NETBIOS file)
 - WDigest is disabled (WDigest file)
@@ -79,8 +79,8 @@ Controls Checklist:
 - Macros are restricted
 - Defender ASR rules are configured (AntiVirus file)
 - Host firewall rules are configured to block inbound (Windows-Firewall and Windows-Firewall-Rules files)
-- GPO Enforce reprocess check (Domain-Hardning file)
-- Always install with elevated privileges setting (Domain-Hardning file)
+- GPO Enforce reprocess check (Domain-Hardening file)
+- Always install with elevated privileges setting (Domain-Hardening file)
 ##########################################################
 @Haim Nachmias @Nital Ruzin
 ##########################################################>
@@ -97,7 +97,7 @@ function writeToScreen {
     Write-Host $str -ForegroundColor $ForegroundColor
 }
 
-#funtion that writes to file gets 3 params (path = folder , file = file name , str string to write in the file)
+#function that writes to file gets 3 params (path = folder , file = file name , str string to write in the file)
 function writeToFile {
     param (
         $path, $file, $str
@@ -117,27 +117,27 @@ function writeToLog {
     param (
         [string]$str
     )
-    $stemp = (Get-Date).ToString("yyyy/MM/dd HH:mm:ss")
-    $logMassage = "$stemp $str"
+    $stamp = (Get-Date).ToString("yyyy/MM/dd HH:mm:ss")
+    $logMassage = "$stamp $str"
     writeToFile -path $hostname -file "Log_$hostname.txt" -str $logMassage
 }
 
 function getNameForFile{
     param(
         $name,
-        $extention
+        $extension
     )
-    if($null -eq $extention){
-        $extention = ".txt"
+    if($null -eq $extension){
+        $extension = ".txt"
     }
-    return ($name + "_" + $hostname+$extention)
+    return ($name + "_" + $hostname+$extension)
 }
 # get current user privileges
 function dataWhoAmI {
     param (
         $name 
     )
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToScreen -str "Running whoami..." -ForegroundColor Yellow
     writeToLog -str "running DataWhoAmI function"
     writeToFile -file $outputFile -path $folderLocation -str "`Output of `"whoami /all`" command:`r`n"
@@ -164,7 +164,7 @@ function dataIpSettings {
     param (
         $name 
     )
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToScreen -str "Running ipconfig..." -ForegroundColor Yellow
     writeToLog -str "running DataIpSettings function"
     writeToFile -file $outputFile -path $folderLocation -str "`Output of `"ipconfig /all`" command:`r`n" 
@@ -176,7 +176,7 @@ function checkInternetAccess{
     param (
         $name 
     )
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToLog -str "running checkInternetAccess function"
     writeToScreen -str "Trying to ping the internet..." -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str "============= ping -n 2 8.8.8.8 =============" 
@@ -196,7 +196,7 @@ function getNetCon {
     param (
         $name
     )
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToLog -str "running getNetCon function"
     writeToScreen -str "Running netstat..." -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str "============= netstat -nao ============="
@@ -219,13 +219,13 @@ function dataGPO {
         # check if we have connectivity to the domain, or if is a DC
         if (((Get-WmiObject -Class Win32_OperatingSystem).ProductType -eq 2) -or (Test-ComputerSecureChannel))
         {
-            $gpoPath = $folderLocation+"\"+(getNameForFile -name $name -extention ".html")
+            $gpoPath = $folderLocation+"\"+(getNameForFile -name $name -extension ".html")
             writeToScreen -str "Running GPResult to get GPOs..." -ForegroundColor Yellow
             gpresult /f /h $gpoPath
             # /h doesn't exists on Windows 2003, so we run without /h into txt file
             if (!(Test-Path $gpoPath)) {
-                writeToLog -str "Function dataGPO: gpresult faild to export to HTML exporting in txt format"
-                $gpoPath = $folderLocation+"\"+(getNameForFile -name $name -extention ".txt")
+                writeToLog -str "Function dataGPO: gpresult failed to export to HTML exporting in txt format"
+                $gpoPath = $folderLocation+"\"+(getNameForFile -name $name -extension ".txt")
                 gpresult $gpoPath
             }
             else{
@@ -247,13 +247,13 @@ function dataSecurityPolicy {
     )
     writeToLog -str "running dataSecurityPolicy function"
     # to open the *.inf output file, open MMC, add snap-in "Security Templates", right click and choose new path, choose the *.inf file path, and open it
-    $sPPath = $hostname+"\"+(getNameForFile -name $name -extention ".inf")
+    $sPPath = $hostname+"\"+(getNameForFile -name $name -extension ".inf")
     if ($runningAsAdmin)
     {
         writeToScreen -str "Getting security policy settings..." -ForegroundColor Yellow
         secedit /export /CFG $sPPath | Out-Null
         if(!(Test-Path $sPPath)){
-            writeToLog -str "Function dataSecurityPolicy: failed to export security policy unknown resone"
+            writeToLog -str "Function dataSecurityPolicy: failed to export security policy unknown reason"
         }
     }
     else
@@ -269,7 +269,7 @@ function dataWinFeatures {
         $name
     )
     writeToLog -str "running dataWinFeatures function"
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
 
     if ($winVersion.Major -ge 6)
     {    
@@ -297,7 +297,7 @@ function dataWinFeatures {
             }
         }
         else{
-            writeToLog -str "Function dataWinFeatures: unable to run Get-WindowsFeature - requare wubdiws server 2008R2 and above and powershell version 4"
+            writeToLog -str "Function dataWinFeatures: unable to run Get-WindowsFeature - require windows server 2008R2 and above and powershell version 4"
         }
         # get features with Get-WindowsOptionalFeature. Requires Windows 8/2012 or above and run-as-admin
         if ($psVer -ge 4 -and (($winVersion.Major -ge 7) -or ($winVersion.Minor -ge 2))) # version should be 7+ or 6.2+
@@ -312,7 +312,7 @@ function dataWinFeatures {
                 {writeToFile -file $outputFile -path $folderLocation -str "Unable to run Get-WindowsOptionalFeature without running as admin. Consider running again with elevated admin permissions."}
         }
         else {
-            writeToLog -str "Function dataWinFeatures: unable to run Get-WindowsOptionalFeature - requare wubdiws server 8/2008R2 and above and powershell version 4"
+            writeToLog -str "Function dataWinFeatures: unable to run Get-WindowsOptionalFeature - require windows server 8/2008R2 and above and powershell version 4"
         }
         # get features with dism. Requires run-as-admin
         writeToFile -file $outputFile -path $folderLocation -str "============= Output of: dism /online /get-features /format:table | ft =============" 
@@ -332,7 +332,7 @@ function dataInstalledHotfixes {
         $name
     )
     writeToLog -str "running dataInstalledHotfixes function"
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToScreen -str "Getting installed hotfixes..." -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str ("The OS version is: " + [System.Environment]::OSVersion + ". See if this version is supported according to the following pages:")
     writeToFile -file $outputFile -path $folderLocation -str "https://en.wikipedia.org/wiki/List_of_Microsoft_Windows_versions" 
@@ -356,7 +356,7 @@ function dataRunningProcess {
         $name
     )
     writeToLog -str "running dataRunningProcess function"
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToScreen -str "Getting processes..." -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str  "Output of `"Get-Process`" PowerShell command:`r`n"
     try {
@@ -375,7 +375,7 @@ function dataServices {
         $name
     )
     writeToLog -str "running dataServices function"
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToScreen -str "Getting services..." -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str "Output of `"Get-WmiObject win32_service`" PowerShell command:`r`n"
     writeToFile -file $outputFile -path $folderLocation -str (Get-WmiObject win32_service  | Sort-Object displayname | Format-Table -AutoSize DisplayName, Name, State, StartMode, StartName | Out-String -Width 180 | Out-String)
@@ -387,7 +387,7 @@ function dataInstalledSoftware{
         $name
     )
     writeToLog -str "running dataInstalledSoftware function"
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToScreen -str "Getting installed software..." -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str (Get-ItemProperty HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName, DisplayVersion, Publisher, InstallDate | Sort-Object DisplayName | Out-String -Width 180 | Out-String)
 }
@@ -398,7 +398,7 @@ function dataSharedFolders{
         $name
     )
     writeToLog -str "running dataSharedFolders function"
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToScreen -str "Getting shared folders..." -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str "============= Shared Folders ============="
     $shares = Get-WmiObject -Class Win32_Share
@@ -451,7 +451,7 @@ function dataAccountPolicy {
         $name
     )
     writeToLog -str "running dataAccountPolicy function"
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToScreen -str "Getting local and domain account policy..." -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str "============= Local Account Policy ============="
     writeToFile -file $outputFile -path $folderLocation -str "Output of `"NET ACCOUNTS`" command:`r`n"
@@ -485,7 +485,7 @@ function dataLocalUsers {
     )
     # only run if no running on a domain controller
     writeToLog -str "running dataLocalUsers function"
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     if ((Get-WmiObject -Class Win32_OperatingSystem).ProductType -ne 2)
     {
         writeToScreen -str "Getting local users + administrators..." -ForegroundColor Yellow
@@ -507,7 +507,7 @@ function dataLocalUsers {
                 writeToFile -file $outputFile -path $folderLocation -str (Get-CimInstance win32_useraccount -Namespace "root\cimv2" -Filter "LocalAccount='$True'" | Select-Object Caption,Disabled,Lockout,PasswordExpires,PasswordRequired,Description,SID | format-table -autosize | Out-String -Width 180 | Out-String)
             }
             else{
-                writeToLog -str "Function dataLocalUsers: unsupported powershell version to run Get-CimInstance skiping..."
+                writeToLog -str "Function dataLocalUsers: unsupported powershell version to run Get-CimInstance skipping..."
             }
         }
     }
@@ -520,7 +520,7 @@ function checkSMBHardening {
         $name
     )
     writeToLog -str "running checkSMBHardening function"
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToScreen -str "Getting SMB hardening configuration..." -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str "============= SMB versions Support (Server Settings) =============" 
     # Check if Windows Vista/2008 or above and powershell version 4 and up 
@@ -653,7 +653,7 @@ function dataRDPSecuirty {
         $name
     )
     writeToLog -str "running dataRDPSecuirty function"
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToScreen -str "Getting RDP security settings..." -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str "============= Raw RDP Settings (from WMI) ============="
     $WMIFilter = "TerminalName='RDP-tcp'" # there might be issues with the quotation marks - to debug
@@ -694,7 +694,7 @@ function dataCredentialGuard {
         $name
     )
     writeToLog -str "running dataCredentialGuard function"
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     if ($winVersion.Major -ge 10)
     {
         writeToScreen -str "Getting credential guard settings..." -ForegroundColor Yellow
@@ -736,7 +736,7 @@ function dataLSAProtectionConf {
         $name
     )
     writeToLog -str "running dataLSAProtectionConf function"
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     if (($winVersion.Major -ge 10) -or (($winVersion.Major -eq 6) -and ($winVersion.Minor -eq 3)))
     {
         writeToScreen -str "Getting LSA protection settings..." -ForegroundColor Yellow
@@ -763,7 +763,7 @@ function checkSensitiveInfo {
     param (
         $name
     )   
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     if ($EnableSensitiveInfoSearch)
     {
         writeToLog -str "running checkSensitiveInfo function"
@@ -801,7 +801,7 @@ function checkAntiVirusStatus {
         $name
     )
     writeToLog -str "running checkAntiVirusStatus function"
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     # works only on Windows Clients, Not on Servers (2008, 2012, etc.). Maybe the "Get-MpPreference" could work on servers - wasn't tested.
     if ((Get-WmiObject -Class Win32_OperatingSystem).ProductType -eq 1)
     {
@@ -892,7 +892,7 @@ function dataWinFirewall {
     param (
         $name
     )
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToLog -str "running dataWinFirewall function"
     writeToScreen -str "Getting Windows Firewall configuration..." -ForegroundColor Yellow
     if ((Get-Service mpssvc).status -eq "Running")
@@ -906,7 +906,7 @@ function dataWinFirewall {
             writeToFile -file $outputFile -path $folderLocation -str (Get-NetFirewallProfile -PolicyStore ActiveStore | Out-String)   
             writeToFile -file $outputFile -path $folderLocation -str "----------------------------------`r`n"
             writeToFile -file $outputFile -path $folderLocation -str "The output of Get-NetFirewallRule can be found in the Windows-Firewall-Rules CSV file. No port and IP information there."
-            $temp = $folderLocation + "\" + (getNameForFile -name $name -extention ".csv")
+            $temp = $folderLocation + "\" + (getNameForFile -name $name -extension ".csv")
             #Get-NetFirewallRule -PolicyStore ActiveStore | Export-Csv $temp -NoTypeInformation - removed replaced by Nir's Offer
             writeToLog -str "Function dataWinFirewall: Exporting to CSV"
             Get-NetFirewallRule -PolicyStore ActiveStore | Where-Object { $_.Enabled -eq $True } | Select-Object -Property PolicyStoreSourceType, Name, DisplayName, DisplayGroup,
@@ -920,13 +920,13 @@ function dataWinFirewall {
             Enabled, Profile, Direction, Action | export-csv -NoTypeInformation $temp
         }
         else{
-            writeToLog -str "Function dataWinFirewall: unable to run NetFirewall commands - skiping (old OS \ powershell is below 4)"
+            writeToLog -str "Function dataWinFirewall: unable to run NetFirewall commands - skipping (old OS \ powershell is below 4)"
         }
         if ($runningAsAdmin)
         {
             writeToFile -file $outputFile -path $folderLocation -str "----------------------------------`r`n"
             writeToLog -str "Function dataWinFirewall: Exporting to wfw" 
-            $temp = $folderLocation + "\" + (getNameForFile -name $name -extention ".wfw")
+            $temp = $folderLocation + "\" + (getNameForFile -name $name -extension ".wfw")
             netsh advfirewall export $temp | Out-Null
             writeToFile -file $outputFile -path $folderLocation -str "Firewall rules exported into $temp" 
             writeToFile -file $outputFile -path $folderLocation -str "To view it, open gpmc.msc in a test environment, create a temporary GPO, get to Computer=>Policies=>Windows Settings=>Security Settings=>Windows Firewall=>Right click on Firewall icon=>Import Policy"
@@ -944,7 +944,7 @@ function checkLLMNRAndNetBIOS {
         $name
     )
     # LLMNR and NETBIOS-NS are insecure legacy protocols for local multicast DNS queries that can be abused by Responder/Inveigh
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToLog -str "running checkLLMNRAndNetBIOS function"
     writeToScreen -str "Getting LLMNR and NETBIOS-NS configuration..." -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str "============= LLMNR Configuration ============="
@@ -990,7 +990,7 @@ function checkWDigest {
     )
     # turned on by default for Win7/2008/8/2012, to fix it you must install kb2871997 and than fix the registry value below
     # turned off by default for Win8.1/2012R2 and above
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToLog -str "running checkWDigest function"
     writeToScreen -str "Getting WDigest credentials configuration..." -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str "============= WDigest Configuration ============="
@@ -1034,7 +1034,7 @@ function checkNetSessionEnum {
     param (
         $name
     )
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToLog -str "running checkNetSessionEnum function"
     writeToScreen -str "Getting NetSession configuration..." -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str "============= NetSession Configuration ============="
@@ -1063,12 +1063,12 @@ function checkSAMEnum{
     param(
         $name
     )
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToLog -str "running checkSAMEnum function"
     writeToScreen -str "Getting SAM enumeration configuration..." -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str "============= Remote SAM (SAMR) Configuration ============="
     writeToFile -file $outputFile -path $folderLocation -str "`r`nBy default, in Windows 2016 (and above) and Windows 10 build 1607 (and above), only Administrators are allowed to make remote calls to SAM with the SAMRPC protocols, and (among other things) enumerate the members of the local groups."
-    writeToFile -file $outputFile -path $folderLocation -str "However, in older OS versions, low privileged domain users can also query the SAM with SAMRPC, which is a major vulnerability mainly on non-Domain Contollers, enabling valuable reconnaissance, as leveraged by BloodHound."
+    writeToFile -file $outputFile -path $folderLocation -str "However, in older OS versions, low privileged domain users can also query the SAM with SAMRPC, which is a major vulnerability mainly on non-Domain Controllers, enabling valuable reconnaissance, as leveraged by BloodHound."
     writeToFile -file $outputFile -path $folderLocation -str "These old OS versions (Windows 7/2008R2 and above) can be hardened by installing a KB and configuring only the Local Administrators group in the following GPO policy: 'Network access: Restrict clients allowed to make remote calls to SAM'."
     writeToFile -file $outputFile -path $folderLocation -str "The newer OS versions are also recommended to be configured with the policy, though it is not essential."
     writeToFile -file $outputFile -path $folderLocation -str "`r`nSee more details here:"
@@ -1100,7 +1100,7 @@ function checkPowershellVer {
     param (
         $name
     )
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToLog -str "running checkPowershellVer function"
     writeToScreen -str "Getting PowerShell versions..." -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str "PowerShell 1/2 are legacy versions which don't support logging and AMSI."
@@ -1146,7 +1146,7 @@ function checkPowershellVer {
         }    
     }
     else {
-        writeToLog -str "Function checkPowershellVer: unable to run Get-WindowsFeature - requare wubdiws server 2008R2 and above and powershell version 4"
+        writeToLog -str "Function checkPowershellVer: unable to run Get-WindowsFeature - require windows server 2008R2 and above and powershell version 4"
     }
     # use Get-WindowsOptionalFeature if running on Windows 8/2012 or above, and running as admin and powershell is equal or above version 4
     if ($psVer -ge 4 -and (($winVersion.Major -gt 6) -or (($winVersion.Major -eq 6) -and ($winVersion.Minor -ge 2)))) # version should be 6.2+
@@ -1162,7 +1162,7 @@ function checkPowershellVer {
         }
     }
     else {
-        writeToLog -str "Function checkPowershellVer: unable to run Get-WindowsOptionalFeature - requare wubdiws server 8/2012R2 and above and powershell version 4"
+        writeToLog -str "Function checkPowershellVer: unable to run Get-WindowsOptionalFeature - require windows server 8/2012R2 and above and powershell version 4"
     }
     # run registry check
     writeToFile -file $outputFile -path $folderLocation -str "============= Registry Check =============" 
@@ -1185,25 +1185,25 @@ function checkNTLMv2 {
     param (
         $name
     )
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToLog -str "running checkNTLMv2 function"
-    writeToScreen -str "Getting NTLM version enforcment..." -ForegroundColor Yellow
+    writeToScreen -str "Getting NTLM version enforcement..." -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str "============= NTLM Check ============="
     writeToFile -file $outputFile -path $folderLocation -str "NTLMv1 & LM are  legacy authentication protocols that are reversible"
-    writeToFile -file $outputFile -path $folderLocation -str "If there are legacy systems in the network configure Level 3 NTLM hardning on the domain (that way only the lagacy system will use the legacy authentication) otherwise select Level 5"
+    writeToFile -file $outputFile -path $folderLocation -str "If there are legacy systems in the network configure Level 3 NTLM hardening on the domain (that way only the legacy system will use the legacy authentication) otherwise select Level 5"
     writeToFile -file $outputFile -path $folderLocation -str "For more information go to: https://docs.microsoft.com/en-us/troubleshoot/windows-client/windows-security/enable-ntlm-2-authentication `r`n"
-    $temp = Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Lsa" -Name LmCompatibilityLevel -ErrorAction SilentlyContinue # registry key that contains the NTLM restrications
+    $temp = Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Lsa" -Name LmCompatibilityLevel -ErrorAction SilentlyContinue # registry key that contains the NTLM restrictions
     if($null -eq $temp){
-        writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authntication setting: (Level Unknown) LM and NTLMv1 restriction does not exist - using OS default`r`n" #using system default depends on OS version
+        writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level Unknown) LM and NTLMv1 restriction does not exist - using OS default`r`n" #using system default depends on OS version
     }
     switch ($temp.lmcompatibilitylevel) {
-        (0) { writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authntication setting: (Level 0) Send LM and NTLM response; never use NTLM 2 session security. Clients use LM and NTLM authentication, and never use NTLM 2 session security; domain controllers accept LM, NTLM, and NTLM 2 authentication. - this is a finding!`r`n" }
-        (1) { writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authntication setting: (Level 1) Use NTLM 2 session security if negotiated. Clients use LM and NTLM authentication, and use NTLM 2 session security if the server supports it; domain controllers accept LM, NTLM, and NTLM 2 authentication. - this is a finding!`r`n" }
-        (2) { writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authntication setting: (Level 2) Send NTLM response only. Clients use only NTLM authentication, and use NTLM 2 session security if the server supports it; domain controllers accept LM, NTLM, and NTLM 2 authentication. - this is a finding!`r`n" }
-        (3) { writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authntication setting: (Level 3) Send NTLM 2 response only. Clients use NTLM 2 authentication, and use NTLM 2 session security if the server supports it; domain controllers accept LM, NTLM, and NTLM 2 authentication. - Not a finding if all servers are with the same configuration`r`n"}
-        (4) { writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authntication setting: (Level 4) Domain controllers refuse LM responses. Clients use NTLM authentication, and use NTLM 2 session security if the server supports it; domain controllers refuse LM authentication (that is, they accept NTLM and NTLM 2) - Not a finding if all servers are with the same configuration`r`n"}
-        (5) { writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authntication setting: (Level 5) Domain controllers refuse LM and NTLM responses (accept only NTLM 2). Clients use NTLM 2 authentication, use NTLM 2 session security if the server supports it; domain controllers refuse NTLM and LM authentication (they accept only NTLM 2 - A good thing!)`r`n"}
-        Default {writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authntication setting: (Level Unknown) - " + $temp.lmcompatibilitylevel + "`r`n"}
+        (0) { writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 0) Send LM and NTLM response; never use NTLM 2 session security. Clients use LM and NTLM authentication, and never use NTLM 2 session security; domain controllers accept LM, NTLM, and NTLM 2 authentication. - this is a finding!`r`n" }
+        (1) { writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 1) Use NTLM 2 session security if negotiated. Clients use LM and NTLM authentication, and use NTLM 2 session security if the server supports it; domain controllers accept LM, NTLM, and NTLM 2 authentication. - this is a finding!`r`n" }
+        (2) { writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 2) Send NTLM response only. Clients use only NTLM authentication, and use NTLM 2 session security if the server supports it; domain controllers accept LM, NTLM, and NTLM 2 authentication. - this is a finding!`r`n" }
+        (3) { writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 3) Send NTLM 2 response only. Clients use NTLM 2 authentication, and use NTLM 2 session security if the server supports it; domain controllers accept LM, NTLM, and NTLM 2 authentication. - Not a finding if all servers are with the same configuration`r`n"}
+        (4) { writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 4) Domain controllers refuse LM responses. Clients use NTLM authentication, and use NTLM 2 session security if the server supports it; domain controllers refuse LM authentication (that is, they accept NTLM and NTLM 2) - Not a finding if all servers are with the same configuration`r`n"}
+        (5) { writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 5) Domain controllers refuse LM and NTLM responses (accept only NTLM 2). Clients use NTLM 2 authentication, use NTLM 2 session security if the server supports it; domain controllers refuse NTLM and LM authentication (they accept only NTLM 2 - A good thing!)`r`n"}
+        Default {writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level Unknown) - " + $temp.lmcompatibilitylevel + "`r`n"}
     }
 }
 
@@ -1212,32 +1212,32 @@ function checkGPOReprocess {
     param (
         $name
     )
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToLog -str "running checkGPOReprocess function"
-    writeToScreen -str "Getting GPO enforcment..." -ForegroundColor Yellow
+    writeToScreen -str "Getting GPO enforcement..." -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str "`r`n============= GPO Reprocess Check ============="
     writeToFile -file $outputFile -path $folderLocation -str "If GPO reprocess is not enforced once the GPO received is the first and lest time the gpo is enforced (until next change)"
-    writeToFile -file $outputFile -path $folderLocation -str "GPO can be overridden with administrator premission - it is recommended that all security settings will be repossessed every time the system checks for GPO change`r`n"
-    $temp = Get-ItemProperty -Path "HKLM:\Software\Policies\Microsoft\Windows\Group Policy\{35378EAC-683F-11D2-A89A-00C04FBBCFA2}" -Name NoGPOListChanges -ErrorAction SilentlyContinue # registry that contains registry polciy reprocess settings 
+    writeToFile -file $outputFile -path $folderLocation -str "GPO can be overridden with administrator permission - it is recommended that all security settings will be repossessed every time the system checks for GPO change`r`n"
+    $temp = Get-ItemProperty -Path "HKLM:\Software\Policies\Microsoft\Windows\Group Policy\{35378EAC-683F-11D2-A89A-00C04FBBCFA2}" -Name NoGPOListChanges -ErrorAction SilentlyContinue # registry that contains registry policy reprocess settings 
     if($null -eq $temp){
-        writeToFile -file $outputFile -path $folderLocation -str ' > GPO regirstry policy reprocess is not configured "processed even if not changed"' 
+        writeToFile -file $outputFile -path $folderLocation -str ' > GPO registry policy reprocess is not configured "processed even if not changed"' 
     }
     elseif ($temp.NoGPOListChanges -ne 0) {
-        writeToFile -file $outputFile -path $folderLocation -str ' > GPO regirstry policy reprocess is not configured currectly "processed even if not changed"' 
+        writeToFile -file $outputFile -path $folderLocation -str ' > GPO registry policy reprocess is not configured correctly "processed even if not changed"' 
     }
     $temp = Get-ItemProperty -Path "HKLM:\Software\Policies\Microsoft\Windows\Group Policy\{42B5FAAE-6536-11d2-AE5A-0000F87571E3}" -Name NoGPOListChanges -ErrorAction SilentlyContinue # registry that contains script policy reprocess settings 
     if($null -eq $temp){
         writeToFile -file $outputFile -path $folderLocation -str ' > GPO script policy reprocess is not configured "processed even if not changed"' 
     }
     elseif ($temp.NoGPOListChanges -ne 0) {
-        writeToFile -file $outputFile -path $folderLocation -str ' > GPO script policy reprocess is not configured currectly "processed even if not changed"' 
+        writeToFile -file $outputFile -path $folderLocation -str ' > GPO script policy reprocess is not configured correctly "processed even if not changed"' 
     }
     $temp = Get-ItemProperty -Path "HKLM:\Software\Policies\Microsoft\Windows\Group Policy\{827D319E-6EAC-11D2-A4EA-00C04F79F83A}" -Name NoGPOListChanges -ErrorAction SilentlyContinue # registry that contains security policy reprocess settings 
     if($null -eq $temp){
         writeToFile -file $outputFile -path $folderLocation -str ' > GPO security policy reprocess is not configured "processed even if not changed"'
     }
     elseif ($temp.NoGPOListChanges -ne 0) {
-        writeToFile -file $outputFile -path $folderLocation -str ' > GPO security policy reprocess is not configured currectly "processed even if not changed"'
+        writeToFile -file $outputFile -path $folderLocation -str ' > GPO security policy reprocess is not configured correctly "processed even if not changed"'
     }
     
 }
@@ -1247,7 +1247,7 @@ function checkInstallElevated {
     param (
         $name
     )
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToLog -str "running checkInstallElevated function"
     writeToScreen -str "Getting Always install with elevation setting..." -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str "`r`n============= Always install elevated Check ============="
@@ -1260,7 +1260,7 @@ function checkInstallElevated {
         writeToFile -file $outputFile -path $folderLocation -str ' > Always install with elevated is enabled - this is a finding!'
     }
     else{
-        writeToFile -file $outputFile -path $folderLocation -str ' > GPO for "Always install with elevated" is existing but not forceing installing with elevation'
+        writeToFile -file $outputFile -path $folderLocation -str ' > GPO for "Always install with elevated" is existing but not enforcing installing with elevation'
     }
     
 }
@@ -1270,7 +1270,7 @@ function checkPowrshellAudit {
     param (
         $name
     )
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToLog -str "running checkPowrshellAudit function"
     writeToScreen -str "Getting Powershell audit policy..." -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str "`r`n============= PowerShell Audit ============="
@@ -1354,7 +1354,7 @@ function checkPowrshellAudit {
     }
     # --- End of ScriptBlock logging
     # --- Start Transcription logging 
-    writeToFile -file $outputFile -path $folderLocation -str "--- PowerShell Transcripting logging: "
+    writeToFile -file $outputFile -path $folderLocation -str "--- PowerShell Transcription logging: "
     $temp = Get-ItemProperty -Path "HKLM:\Software\Policies\Microsoft\Windows\PowerShell\Transcription" -Name EnableTranscripting -ErrorAction SilentlyContinue # registry containing transcripting logging setting - computer-space
     $bollCheck = $false
     if($null -eq $temp -or $temp.EnableTranscripting -ne 1){
@@ -1371,12 +1371,12 @@ function checkPowrshellAudit {
                 $bollCheck = $True
             }
             if(!$bollCheck){
-                writeToFile -file $outputFile -path $folderLocation -str " > Powershell - Transcription logging is enforced currectly but only on the user"
+                writeToFile -file $outputFile -path $folderLocation -str " > Powershell - Transcription logging is enforced correctly but only on the user"
                 $bollCheck = $True
             }
         }
         else{
-            writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Transcription logging is not enforced (logging input and outpot of powershell command)"
+            writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Transcription logging is not enforced (logging input and output of powershell command)"
             $bollCheck = $True
         }
     }
@@ -1393,7 +1393,7 @@ function checkPowrshellAudit {
         }
     }
     if(!$bollCheck){
-        writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Transcription logging is enabled and configured currectly" 
+        writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Transcription logging is enabled and configured correctly" 
     }
     
 }
@@ -1403,7 +1403,7 @@ function dataSystemInfo {
     param (
         $name
     )
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToLog -str "running dataSystemInfo function"
     writeToScreen -str "Running systeminfo..." -ForegroundColor Yellow
     # Get-ComputerInfo exists only in PowerShell 5.1 and above
@@ -1421,7 +1421,7 @@ function dataAuditPolicy {
     param (
         $name
     )
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToLog -str "running dataAuditSettings function"
     writeToScreen -str "getting audit policy settings..." -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str "`r`n============= Audit Policy Configuration ============="
@@ -1440,20 +1440,20 @@ function checkCommandLineAudit {
     param (
         $name
     )
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToLog -str "running checkCommandLineAudit function"
     writeToScreen -str "checking command line audit..." -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str "`r`n============= Command line Audit ============="
     writeToFile -file $outputFile -path $folderLocation -str "Command line Audit tracks all commands running in the CLI"
     writeToFile -file $outputFile -path $folderLocation -str "Supported windows is 8/2012R2 and above"
 
-    $reg = Get-ItemProperty -Path "HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System\Audit" -Name "ProcessCreationIncludeCmdLine_Enabled" -ErrorAction SilentlyContinue # registry key that contains the NTLM restrications
+    $reg = Get-ItemProperty -Path "HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System\Audit" -Name "ProcessCreationIncludeCmdLine_Enabled" -ErrorAction SilentlyContinue # registry key that contains the NTLM restrictions
     if ((($winVersion.Major -ge 7) -or ($winVersion.Minor -ge 2))){
         if($null -eq $reg){
             writeToFile -file $outputFile -path $folderLocation -str " > Command line audit policy is not configured - this is bad" #using system default depends on OS version
         }
         elseif($reg.ProcessCreationIncludeCmdLine_Enabled -ne 1){
-            writeToFile -file $outputFile -path $folderLocation -str " > Command line audit policy is not configured currectly - this is bad" #using system default depends on OS version
+            writeToFile -file $outputFile -path $folderLocation -str " > Command line audit policy is not configured correctly - this is bad" #using system default depends on OS version
         }
         else{
             if($runningAsAdmin)
@@ -1461,10 +1461,10 @@ function checkCommandLineAudit {
                 $test = auditpol /get /category:*
                 foreach ($item in $test){
                     if($item -like "*Process Creation*No Auditing"){
-                        writeToFile -file $outputFile -path $folderLocation -str " > Command line audit policy is not configured currectly (Advance audit>Detailed Tracking>Process Creation is not configured)  - this is bad" 
+                        writeToFile -file $outputFile -path $folderLocation -str " > Command line audit policy is not configured correctly (Advance audit>Detailed Tracking>Process Creation is not configured)  - this is bad" 
                     }
                     elseif ($item -like "*Process Creation*") {
-                        writeToFile -file $outputFile -path $folderLocation -str " > Command line audit policy is configured currectly - this is good" 
+                        writeToFile -file $outputFile -path $folderLocation -str " > Command line audit policy is configured correctly - this is good" 
                     }
                 }
             }
@@ -1483,7 +1483,7 @@ function checkLogSize {
     param (
         $name
     )
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToLog -str "running checkLogSize function"
     writeToScreen -str "checking log size configuration..." -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str "`r`n============= log size configuration ============="
@@ -1506,7 +1506,7 @@ function checkLogSize {
         $size = $Calc.tostring() + $size
         writeToFile -file $outputFile -path $folderLocation -str " > Application maximum log file is $size"
         if($applicationLogMaxSize.MaxSize -lt 32768){
-            writeToFile -file $outputFile -path $folderLocation -str " > Application maximum log file size is smaller then the recommandation (32768KB) - this is a finding"
+            writeToFile -file $outputFile -path $folderLocation -str " > Application maximum log file size is smaller then the recommendation (32768KB) - this is a finding"
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > Application maximum log file size is equal or larger then (32768KB) - this is good"
@@ -1528,7 +1528,7 @@ function checkLogSize {
         $size = $Calc.tostring() + $size
         writeToFile -file $outputFile -path $folderLocation -str " > System maximum log file is $size"
         if($systemLogMaxSize.MaxSize -lt 32768){
-            writeToFile -file $outputFile -path $folderLocation -str " > System maximum log file size is smaller then the recommandation (32768KB) - this is a finding"
+            writeToFile -file $outputFile -path $folderLocation -str " > System maximum log file size is smaller then the recommendation (32768KB) - this is a finding"
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > System maximum log file size is equal or larger then (32768KB) - this is good"
@@ -1550,7 +1550,7 @@ function checkLogSize {
         $size = $Calc.tostring() + $size
         writeToFile -file $outputFile -path $folderLocation -str " > Security maximum log file is $size"
         if($securityLogMaxSize.MaxSize -lt 196604){
-            writeToFile -file $outputFile -path $folderLocation -str " > Security maximum log file size is smaller then the recommandation (196604KB ) - this is a finding"
+            writeToFile -file $outputFile -path $folderLocation -str " > Security maximum log file size is smaller then the recommendation (196604KB ) - this is a finding"
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > Security maximum log file size is equal or larger then (32768KB) - this is good"
@@ -1572,7 +1572,7 @@ function checkLogSize {
             $size = [String]::Parse($Calc) + $size
             writeToFile -file $outputFile -path $folderLocation -str " > Setup maximum log file is $size"
             if($setupLogMaxSize.MaxSize -lt 32768){
-                writeToFile -file $outputFile -path $folderLocation -str " > System maximum log file size is smaller then the recommandation (32768KB) - this is a finding"
+                writeToFile -file $outputFile -path $folderLocation -str " > System maximum log file size is smaller then the recommendation (32768KB) - this is a finding"
             }
             else{
                 writeToFile -file $outputFile -path $folderLocation -str " > System maximum log file size is equal or larger then (32768KB) - this is good"
@@ -1593,15 +1593,15 @@ function checkSafeModeAcc4NonAdmin {
     param (
         $name
     )
-    $outputFile = getNameForFile -name $name -extention ".txt"
+    $outputFile = getNameForFile -name $name -extension ".txt"
     writeToLog -str "running checkSafeModeAcc4NonAdmin function"
     writeToScreen -str "Checking if safe mode access by non-admins is blocked" -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str "`r`n============= Safe mode access by non-admins ============="
-    writeToFile -file $outputFile -path $folderLocation -str "If safe mode can be accessed by non admins there is an option of privilege escalation on this machine for an attacker - requared diract access"
+    writeToFile -file $outputFile -path $folderLocation -str "If safe mode can be accessed by non admins there is an option of privilege escalation on this machine for an attacker - required direct access"
 
-    $reg = Get-ItemProperty -Path "HKLM\SOFTWARE\Microsoft\Windows\Curr entVersion\Policies\System" -Name "SafeModeBlockNonAdmins" -ErrorAction SilentlyContinue # registry key that contains the safe mode resrication
+    $reg = Get-ItemProperty -Path "HKLM\SOFTWARE\Microsoft\Windows\Curr entVersion\Policies\System" -Name "SafeModeBlockNonAdmins" -ErrorAction SilentlyContinue # registry key that contains the safe mode restriction
     if($null -eq $reg){
-        writeToFile -file $outputFile -path $folderLocation -str " > No hardning on Safe mode access by non admins - might be a finding"
+        writeToFile -file $outputFile -path $folderLocation -str " > No hardening on Safe mode access by non admins - might be a finding"
     }
     else{
         if($reg.SafeModeBlockNonAdmins -eq 1){
@@ -1613,7 +1613,7 @@ function checkSafeModeAcc4NonAdmin {
     }
 }
 
-###Genral Vals
+###General val's
 # get hostname to use as the folder name and file names
 $hostname = hostname
 $folderLocation = $hostname
@@ -1739,10 +1739,10 @@ checkSAMEnum -name "SAM-Enumeration"
 checkPowershellVer -name "PowerShell-Versions"
 
 # NTLMv2 enforcement check - check if there is a GPO that enforce the use of NTLMv2 (checking registry)
-checkNTLMv2 -name "Domain-Hardning"
+checkNTLMv2 -name "Domain-Hardening"
 
 # GPO reprocess check
-checkGPOReprocess -name "Domain-Hardning"
+checkGPOReprocess -name "Domain-Hardening"
 
 # Commandline Audit settings check
 checkCommandLineAudit -name "Audit-Policy"
@@ -1757,10 +1757,10 @@ checkLogSize -name "Audit-Policy"
 dataAuditPolicy -name "Audit-Policy"
 
 # Check always install elevated setting
-checkInstallElevated -name "Domain-Hardning"
+checkInstallElevated -name "Domain-Hardening"
 
 #Check if safe mode access by non-admins is blocked
-checkSafeModeAcc4NonAdmin -name "Domain-Hardning"
+checkSafeModeAcc4NonAdmin -name "Domain-Hardening"
 
 # get various system info (can take a few seconds)
 dataSystemInfo -name "Systeminfo"
@@ -1792,7 +1792,7 @@ elseif ($psVer -eq 4 ) {
 }
 else{
     writeToScreen -str "All Done! Please ZIP all the files and send it back." -ForegroundColor Green
-    writeToLog -str "powershell running the script is below 4 script is not supporting ziping below that"
+    writeToLog -str "powershell running the script is below 4 script is not supporting compression to zip below that"
 }
 
 $endTime = Get-Date

--- a/WindowsAssessment.ps1
+++ b/WindowsAssessment.ps1
@@ -144,8 +144,10 @@ function dataWhoAmI {
     # when running whoami /all and not connected to the domain, claims information cannot be fetched and an error occurs. Temporarily silencing errors to avoid this.
     #$PrevErrorActionPreference = $ErrorActionPreference
     #$ErrorActionPreference = "SilentlyContinue"
-    $tmp = Test-ComputerSecureChannel -ErrorAction SilentlyContinue
-    if($null -eq $tmp ){
+    if ((Get-WmiObject -Class Win32_OperatingSystem).ProductType -ne 2){
+        $tmp = Test-ComputerSecureChannel -ErrorAction SilentlyContinue
+    }
+    else{
         $tmp = $true
     }
     if ((Get-WmiObject -Class Win32_ComputerSystem).PartOfDomain -and (!$tmp))
@@ -199,7 +201,12 @@ function checkInternetAccess{
     if($psVer -ge 4){
         writeToFile -file $outputFile -path $folderLocation -str "============= curl -DisableKeepAlive -TimeoutSec 2 -Uri http://portquiz.net =============" 
         $test = $null
-        $test = Invoke-WebRequest -DisableKeepAlive -TimeoutSec 2 -Uri "http://portquiz.net" -ErrorAction SilentlyContinue
+        try{
+            $test = Invoke-WebRequest -DisableKeepAlive -TimeoutSec 3 -Uri "http://portquiz.net" -ErrorAction SilentlyContinue
+        }
+        catch{
+            $test = $null
+        }
         if($null -ne $test){
             if($test.StatusCode -eq 200){
                 writeToFile -file $outputFile -path $folderLocation -str " > port 80 is open " 
@@ -215,7 +222,13 @@ function checkInternetAccess{
 
         writeToFile -file $outputFile -path $folderLocation -str "============= curl -DisableKeepAlive -TimeoutSec 2 -Uri http://portquiz.net:443 =============" 
         $test = $null
-        $test = Invoke-WebRequest -DisableKeepAlive -TimeoutSec 2 -Uri "http://portquiz.net:443" -ErrorAction SilentlyContinue
+        try{
+            $test = Invoke-WebRequest -DisableKeepAlive -TimeoutSec 3 -Uri "http://portquiz.net:443" -ErrorAction SilentlyContinue
+        }
+        catch{
+            $test = $null
+        }
+        
         if($null -ne $test){
             if($test.StatusCode -eq 200){
                 writeToFile -file $outputFile -path $folderLocation -str " > port 443 is open " 
@@ -231,7 +244,12 @@ function checkInternetAccess{
 
         writeToFile -file $outputFile -path $folderLocation -str "============= curl -DisableKeepAlive -TimeoutSec 2 -Uri http://portquiz.net:666 =============" 
         $test = $null
-        $test = Invoke-WebRequest -DisableKeepAlive -TimeoutSec 2 -Uri "http://portquiz.net:666" -ErrorAction SilentlyContinue
+        try{
+            $test = Invoke-WebRequest -DisableKeepAlive -TimeoutSec 3 -Uri "http://portquiz.net:666" -ErrorAction SilentlyContinue
+        }
+        catch{
+            $test = $null
+        }
         if($null -ne $test){
             if($test.StatusCode -eq 200){
                 writeToFile -file $outputFile -path $folderLocation -str " > port 666 is open " 
@@ -247,7 +265,13 @@ function checkInternetAccess{
 
         writeToFile -file $outputFile -path $folderLocation -str "============= curl -DisableKeepAlive -TimeoutSec 2 -Uri http://portquiz.net:8080 =============" 
         $test = $null
-        $test = Invoke-WebRequest -DisableKeepAlive -TimeoutSec 2 -Uri "http://portquiz.net:8080" -ErrorAction SilentlyContinue
+        try{
+            $test = Invoke-WebRequest -DisableKeepAlive -TimeoutSec 3 -Uri "http://portquiz.net:8080" -ErrorAction SilentlyContinue
+        }
+        catch{
+            $test = $null
+        }
+        
         if($null -ne $test){
             if($test.StatusCode -eq 200){
                 writeToFile -file $outputFile -path $folderLocation -str " > port 8080 is open " 
@@ -421,7 +445,7 @@ function dataInstalledHotfixes {
     writeToFile -file $outputFile -path $folderLocation -str "https://en.wikipedia.org/wiki/Windows_10_version_history" 
     writeToFile -file $outputFile -path $folderLocation -str "https://support.microsoft.com/he-il/help/13853/windows-lifecycle-fact-sheet" 
     writeToFile -file $outputFile -path $folderLocation -str "Output of `"Get-HotFix`" PowerShell command, sorted by installation date:`r`n" 
-    writeToFile -file $outputFile -path $folderLocation -str (Get-HotFix | Sort-Object InstalledOn -Descending -ErrorAction SilentlyContinue )
+    writeToFile -file $outputFile -path $folderLocation -str (Get-HotFix | Sort-Object InstalledOn -Descending -ErrorAction SilentlyContinue | Out-String )
     <# wmic qfe list full /format:$htable > $hostname\hotfixes_$hostname.html
     if ((Get-Content $hostname\hotfixes_$hostname.html) -eq $null)
     {

--- a/WindowsAssessment.ps1
+++ b/WindowsAssessment.ps1
@@ -1,7 +1,7 @@
 param ([Switch]$EnableSensitiveInfoSearch = $false)
 # add the "EnableSensitiveInfoSearch" flag to search for sensitive data
 
-$Version = "1.22" # used for logging purposes
+$Version = "1.23" # used for logging purposes
 ###########################################################
 <# TODO:
 - Output the results to a single file with a simple table
@@ -508,7 +508,7 @@ function dataSharedFolders{
     writeToScreen -str "Getting shared folders..." -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str "============= Shared Folders ============="
     $shares = Get-WmiObject -Class Win32_Share
-    writeToFile -file $outputFile -path $folderLocation -str $shares
+    writeToFile -file $outputFile -path $folderLocation -str ($shares | Out-String )
     # get shared folders + share permissions + NTFS permissions with SmbShare module (exists only in Windows 8 or 2012 and above)
     foreach ($share in $shares)
     {


### PR DESCRIPTION
There is a lot to cover hare:
added 7 checks:
1. NTLMv2 Check
2. PowerShell logging
3. GPO reprocess check
4. install with elevated permission setting check
5. Command line audit check ( Nir suggestion the idea)
6. Local log size check
7. safe mode access by none admins

added Nir's host FW export suggestion 
added log function and configured log for each check in the code
reconfigured the script to run functions 
added flexibility in name convention and log convention by migrating them to a dedicated function
added PowerShell v4 support in zip and PowerShell audit function
fixed PowerShell v2 errors (forcefully running PowerShell v2 on Windows server 2012 reviled the errors):
* windows features
* SMB hardening
* Windows firewall
* PowerShell version
* local users + administrators
fixed bug (will give more consistent result) in SMB check (commented the problem)