### PR TITLE
Version 1.36 - CSV export, Kerberos check and more...

### DIFF
--- a/WindowsAssessment.ps1
+++ b/WindowsAssessment.ps1
@@ -226,11 +226,10 @@ function dataIpSettings {
         $outputFile = getNameForFile -name $name -extension ".csv"
         Get-NetIPConfiguration | Select-object InterfaceDescription -ExpandProperty AllIPAddresses | Export-CSV -path "$folderLocation\$outputFile" -NoTypeInformation -ErrorAction SilentlyContinue
     }
-    else{
-        $outputFile = getNameForFile -name $name -extension ".txt"
-        writeToFile -file $outputFile -path $folderLocation -str "`Output of `"ipconfig /all`" command:`r`n" 
-        writeToFile -file $outputFile -path $folderLocation -str (ipconfig /all) 
-    }
+    $outputFile = getNameForFile -name $name -extension ".txt"
+    writeToFile -file $outputFile -path $folderLocation -str "`Output of `"ipconfig /all`" command:`r`n" 
+    writeToFile -file $outputFile -path $folderLocation -str (ipconfig /all) 
+    
     
 }
 

--- a/WindowsAssessment.ps1
+++ b/WindowsAssessment.ps1
@@ -1402,7 +1402,7 @@ function checkAntiVirusStatus {
             writeToFile -file $outputFile -path $folderLocation -str ("Product Executable: " + $av.pathToSignedProductExe )
             writeToFile -file $outputFile -path $folderLocation -str ("Time Stamp: " + $av.timestamp)
             writeToFile -file $outputFile -path $folderLocation -str ("Product (raw) state: " + $av.productState)
-            sumOutput += ("Product Display name: " + $av.displayname ) + "`n" + ("Product Executable: " + $av.pathToSignedProductExe ) + "`n" + ("Time Stamp: " + $av.timestamp) + "`n" + ("Product (raw) state: " + $av.productState)
+            $sumOutput += ("Product Display name: " + $av.displayname ) + "`n" + ("Product Executable: " + $av.pathToSignedProductExe ) + "`n" + ("Time Stamp: " + $av.timestamp) + "`n" + ("Product (raw) state: " + $av.productState)
             # check the product state
             $hx = '0x{0:x}' -f $av.productState
             if ($hx.Substring(3,2) -match "00|01")
@@ -1491,6 +1491,9 @@ function checkAntiVirusStatus {
         writeToFile -file $outputFile -path $folderLocation -str ($MpPreference.AttackSurfaceReductionRules_Actions | Out-String)
         writeToFile -file $outputFile -path $folderLocation -str "Attack Surface Reduction Only Exclusions:" 
         writeToFile -file $outputFile -path $folderLocation -str $MpPreference.AttackSurfaceReductionOnlyExclusions
+    }
+    else{
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Security" -checkName "AntiVirus installed system" -checkID "machine_AVName" -status $csvUn -finding "AntiVirus test is currently not running on servers"   -risk $csvR2
     }
 }
 
@@ -2951,11 +2954,11 @@ if($partOfDomain){
     $folderLocation = $hostname+"_"+$domainName
 }
 else{
-    $test = (Get-WMIObject win32_operatingsystem).name
+    $temp = (Get-WMIObject win32_operatingsystem).name
     $temp = $temp.Replace(" ","")
     $temp = $temp.Trim("Microsoft")
     $temp = $temp.Replace("Windows","Win")
-    $temp = $temp.Substring(0,$test.IndexOf("|"))
+    $temp = $temp.Substring(0,$temp.IndexOf("|"))
     $folderLocation = $hostname+"_"+$temp
 }
 if(Test-Path $folderLocation){

--- a/WindowsAssessment.ps1
+++ b/WindowsAssessment.ps1
@@ -924,18 +924,18 @@ function checkInternetAccess{
         if($null -ne $test){
             if($test.StatusCode -eq 200){
                 writeToFile -file $outputFile -path $folderLocation -str " > Port 443 is open for outbound internet access. This may be considered a finding, at least on servers." 
-                $naOutput += "`nPort 443: Open"
+                $naOutput += "; Port 443: Open"
                 $naStdPorts = $true
             }
             else {
                 $str = " > test received http code: "+$test.StatusCode+" Port 443 outbound access to internet failed - Firewall URL filtering might block this test."
                 writeToFile -file $outputFile -path $folderLocation -str $str  
-                $naOutput += "`nPort 443: Blocked"
+                $naOutput += "; Port 443: Blocked"
             }
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > Port 443 outbound access to internet failed - received a time out."
-            $naOutput += "`nPort 443: Blocked"
+            $naOutput += "; Port 443: Blocked"
         }
 
         writeToFile -file $outputFile -path $folderLocation -str "============= curl -DisableKeepAlive -TimeoutSec 2 -Uri http://portquiz.net:666 =============" 
@@ -949,18 +949,18 @@ function checkInternetAccess{
         if($null -ne $test){
             if($test.StatusCode -eq 200){
                 writeToFile -file $outputFile -path $folderLocation -str " > Port 666 is open for outbound internet access. This may be considered a finding, at least on servers." 
-                $naOutput += "`nPort 663: Open"
+                $naOutput += "; Port 663: Open"
                 $naNStdPorts = $true
             }
             else {
                 $str = " > test received http code: "+$test.StatusCode+" Port 666 outbound access to internet failed - Firewall URL filtering might block this test."
                 writeToFile -file $outputFile -path $folderLocation -str $str  
-                $naOutput += "`nPort 663: Blocked"
+                $naOutput += "; Port 663: Blocked"
             }
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > Port 666 outbound access to internet failed - received a time out."
-            $naOutput += "`nPort 663: Blocked"
+            $naOutput += "; Port 663: Blocked"
         }
 
         writeToFile -file $outputFile -path $folderLocation -str "============= curl -DisableKeepAlive -TimeoutSec 2 -Uri http://portquiz.net:8080 =============" 
@@ -975,18 +975,18 @@ function checkInternetAccess{
         if($null -ne $test){
             if($test.StatusCode -eq 200){
                 writeToFile -file $outputFile -path $folderLocation -str " > Port 8080 is open for outbound internet access. This may be considered a finding, at least on servers." 
-                $naOutput += "`nPort 8080: Open"
+                $naOutput += "; Port 8080: Open"
                 $naNStdPorts = $true
             }
             else {
                 $str = " > test received http code: "+$test.StatusCode+" Port 8080 outbound access to internet failed - Firewall URL filtering might block this test."
                 writeToFile -file $outputFile -path $folderLocation -str $str  
-                $naOutput += "`nPort 8080: Blocked"
+                $naOutput += "; Port 8080: Blocked"
             }
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > Port 8080 outbound access to internet failed - received a time out."
-            $naOutput += "`nPort 8080: Blocked"
+            $naOutput += "; Port 8080: Blocked"
         }
         if($naStdPorts -and $naNStdPorts){
             addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -problem $true -comment "All ports are open for this machine: $naOutput" 
@@ -1209,7 +1209,7 @@ function checkRDPSecurity {
     }
     else{
         writeToFile -file $outputFile -path $folderLocation -str " > RDP Is enabled on this machine."
-        addToCSV -category "Machine Hardening - RDP" -checkName "RDP Status" -checkID "machine_RDP-reg" -problem $false -comment "RDP Is disabled on this enabled." 
+        addToCSV -category "Machine Hardening - RDP" -checkName "RDP Status" -checkID "machine_RDP-reg" -problem $false -comment "RDP Is enabled on this machine." 
 
     }
     writeToFile -file $outputFile -path $folderLocation -str "============= Remote Desktop Users ============="
@@ -1961,7 +1961,7 @@ function checkPowerShellAudit {
             }
             if(!$booltest){
                 writeToFile -file $outputFile -path $folderLocation -str  " > PowerShell - Module Logging is enabled on all modules but only on the user."
-                addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Modules" -checkID "machine_PSModuleLog" -problem $fasle -comment "Powershell Module Logging is enabled on all modules. (Only on current user)"
+                addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Modules" -checkID "machine_PSModuleLog" -problem $false -comment "Powershell Module Logging is enabled on all modules. (Only on current user)"
 
             }
             else{
@@ -2599,12 +2599,12 @@ function checkUnquotedSePath {
         }
     }
     if ($boolBadPath){
-        addToCSV -category "Vulnerabilities" -checkName "unquoted path" -checkID "vul_quotedPath" -problem $true -comment ("There are vulnerable services in this machine:"+($badPaths | Out-String))
+        addToCSV -category "Vulnerabilities" -checkName "Unquoted path" -checkID "vul_quotedPath" -problem $true -comment ("There are vulnerable services in this machine:"+($badPaths | Out-String))
         writeToFile -file $outputFile -path $folderLocation -str " > There are vulnerable services in this machine:"
         writeToFile -file $outputFile -path $folderLocation -str  ($badPaths | Out-String)
     }
     else{
-        addToCSV -category "Vulnerabilities" -checkName "unquoted path" -checkID "vul_quotedPath" -problem $false -comment "No Service found that is vulnerable with Unquoted path "
+        addToCSV -category "Vulnerabilities" -checkName "Unquoted path" -checkID "vul_quotedPath" -problem $false -comment "No Service found that is vulnerable with Unquoted path "
         writeToFile -file $outputFile -path $folderLocation -str " > The check did not find any service that is vulnerable to unquoted path escalation attack. This is good."
     }
 }
@@ -2647,7 +2647,7 @@ function checkSimulEhtrAndWifi {
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > Minimize the number of simultaneous connections to the Internet or a Windows Domain is not configured"
-            addToCSV -category "Machine Hardening - Networking" -checkName "Ethernet Simultaneous connections " -checkID "machine_ethSim" -problem "UNKNOWN" -comment "Machine is missing configuration for simultaneous Ethernet connections (e.g. for servers it is fine to not configure this setting)"
+            addToCSV -category "Machine Hardening - Networking" -checkName "Ethernet Simultaneous connections " -checkID "machine_ethSim" -problem "UNKNOWN" -comment "Machine is missing configuration for simultaneous Ethernet connections (e.g., for servers it is fine to not configure this setting)"
         }
 
         writeToFile -file $outputFile -path $folderLocation -str "`r`n=== checking if GPO Prohibit connection to non-domain networks when connected to domain authenticated network is configured"
@@ -2665,7 +2665,7 @@ function checkSimulEhtrAndWifi {
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > No configuration found to restrict machine connection to non-domain networks when connected to domain authenticated network"
-            addToCSV -category "Machine Hardening - Networking" -checkName "Prohibit connection to non-domain networks" -checkID "machine_PCTNDNetwork" -problem "UNKNOWN" -comment "No configuration found to restrict machine connection to non-domain networks(e.g. for servers it is fine to not configure this setting)"
+            addToCSV -category "Machine Hardening - Networking" -checkName "Prohibit connection to non-domain networks" -checkID "machine_PCTNDNetwork" -problem "UNKNOWN" -comment "No configuration found to restrict machine connection to non-domain networks(e.g., for servers it is fine to not configure this setting)"
         }
       
     }
@@ -2846,7 +2846,7 @@ function checkKerberos{
                  }
                 2147483616 { 
                     writeToFile -file $outputFile -path $folderLocation -str " > Kerberos encryption allows Future encryption types only - things will not work properly inside the domain (probably)"
-                    addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $true -comment "Kerberos encryption allows Future encryption types only (e.g. dose not allow any encryption"
+                    addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $true -comment "Kerberos encryption allows Future encryption types only (e.g., dose not allow any encryption"
                 }
 
                 0 { 
@@ -2905,7 +2905,7 @@ function checkKerberos{
         writeToFile -file $outputFile -path $folderLocation -str "Kerberos max packet size before using UDP."
         $reg = Get-ItemProperty $kerbPath -Name "MaxPacketSize" -ErrorAction SilentlyContinue
         if($null -eq $reg -or $reg.MaxPacketSize -eq 0){
-            writeToFile -file $outputFile -path $folderLocation -str " > Kerberos max packet size is not configured or set to 0 (e.g. not using UDP at all) - this is a ok"
+            writeToFile -file $outputFile -path $folderLocation -str " > Kerberos max packet size is not configured or set to 0 (e.g., not using UDP at all) - this is a ok"
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > erberos max packet size is set to " + $reg.MaxPacketSize + " - this is a finding!"

--- a/WindowsAssessment.ps1
+++ b/WindowsAssessment.ps1
@@ -182,15 +182,24 @@ function addToCSV {
         $category,
         $checkName,
         $checkID,
-        $problem,
-        $comment
+        $status,
+        $risk,
+        $finding,
+        $comment,
+        $relatedFile,
+        $BPID
+
     )
     $script:checksArray += New-Object -TypeName PSObject -Property @{    
         Category = $category
         CheckName = $checkName
         CheckID = $checkID
-        Problem = $problem
-        Comment = $comment
+        Status = $status
+        Risk = $risk
+        Finding = $finding
+        Comments = $comment
+        'Related file' = $relatedFile
+        BPID = $BPID
       }
 }
 
@@ -763,18 +772,18 @@ function checkCredentialGuard {
         if ($null -eq $DevGuard.SecurityServicesConfigured)
             {
                 writeToFile -file $outputFile -path $folderLocation -str "The WMI query for Device Guard settings has failed. Status unknown."
-                addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-wmi" -problem "UNKNOWN" -comment "WMI query for Device Guard settings has failed." 
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-wmi" -status $csvUn -finding "WMI query for Device Guard settings has failed." 
             }
         else {
             if (($DevGuard.SecurityServicesConfigured -contains 1) -and ($DevGuard.SecurityServicesRunning -contains 1))
             {
                 writeToFile -file $outputFile -path $folderLocation -str "Credential Guard is configured and running. Which is good."
-                addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-wmi" -problem $false -comment "Credential Guard is configured and running." 
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-wmi" -status $csvSt -finding "Credential Guard is configured and running." 
             }
         else
             {
                 writeToFile -file $outputFile -path $folderLocation -str "Credential Guard is turned off. A possible finding."
-                addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-wmi" -problem $true -comment "Credential Guard is turned off." 
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-wmi" -status $csvOp -finding "Credential Guard is turned off." 
         }    
         }
         writeToFile -file $outputFile -path $folderLocation -str "============= Raw Device Guard Settings from WMI (Including Credential Guard) ============="
@@ -784,19 +793,19 @@ function checkCredentialGuard {
         if ($null -eq $DevGuardPS.DeviceGuardSecurityServicesRunning)
             {
                 writeToFile -file $outputFile -path $folderLocation -str "Credential Guard is turned off. A possible finding."
-                addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-PS" -problem $true -comment "Credential Guard is turned off." 
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-PS" -status $csvOp -finding "Credential Guard is turned off." 
         }
         else
         {
             if ($null -ne ($DevGuardPS.DeviceGuardSecurityServicesRunning | Where-Object {$_.tostring() -eq "CredentialGuard"}))
                 {
                     writeToFile -file $outputFile -path $folderLocation -str "Credential Guard is configured and running. Which is good."
-                    addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-PS" -problem $false -comment "Credential Guard is configured and running." 
+                    addToCSV -relatedFile $outputFile -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-PS" -status $csvSt -finding "Credential Guard is configured and running." 
                 }
             else
                 {
                     writeToFile -file $outputFile -path $folderLocation -str "Credential Guard is turned off. A possible finding."
-                    addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-PS" -problem $true -comment "Credential Guard is turned off." 
+                    addToCSV -relatedFile $outputFile -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-PS" -status $csvOp -finding "Credential Guard is turned off." 
                 }
         }
         writeToFile -file $outputFile -path $folderLocation -str "============= Raw Device Guard Settings from Get-ComputerInfo ============="
@@ -804,8 +813,8 @@ function checkCredentialGuard {
     }
     else{
         writeToLog -str "Function checkCredentialGuard: not supported OS no check is needed..."
-        addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-PS" -problem $true -comment "OS not supporting Credential Guard." 
-        addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-wmi" -problem $true -comment "OS not supporting Credential Guard." 
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-PS" -status $csvOp -finding "OS not supporting Credential Guard." 
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-wmi" -status $csvOp -finding "OS not supporting Credential Guard." 
     }
     
 }
@@ -824,7 +833,7 @@ function checkLSAProtectionConf {
         if ($null -eq $RunAsPPL)
             {
                 writeToFile -file $outputFile -path $folderLocation -str "RunAsPPL registry value does not exists. LSA protection is off . Which is bad and a possible finding."
-                addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - PPL" -checkID "machine_LSA-ppl" -problem $true -comment "RunAsPPL registry value does not exists. LSA protection is off." 
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Authentication" -checkName "LSA Protection - PPL" -checkID "machine_LSA-ppl" -status $csvOp -finding "RunAsPPL registry value does not exists. LSA protection is off." 
             }
         else
         {
@@ -832,19 +841,19 @@ function checkLSAProtectionConf {
             if ($RunAsPPL.RunAsPPL -eq 1)
                 {
                     writeToFile -file $outputFile -path $folderLocation -str "LSA protection is on. Which is good."
-                    addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - PPL" -checkID "machine_LSA-ppl" -problem $false -comment "LSA protection is on." 
+                    addToCSV -relatedFile $outputFile -category "Machine Hardening - Authentication" -checkName "LSA Protection - PPL" -checkID "machine_LSA-ppl" -status $csvSt -finding "LSA protection is on." 
 
                 }
             else
                 {
                     writeToFile -file $outputFile -path $folderLocation -str "LSA protection is off. Which is bad and a possible finding."
-                    addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - PPL" -checkID "machine_LSA-ppl" -problem $true -comment "LSA protection is off (PPL)." 
+                    addToCSV -relatedFile $outputFile -category "Machine Hardening - Authentication" -checkName "LSA Protection - PPL" -checkID "machine_LSA-ppl" -status $csvOp -finding "LSA protection is off (PPL)." 
             }
         }
     }
     else{
         writeToLog -str "Function checkLSAProtectionConf: not supported OS no check is needed"
-        addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - PPL" -checkID "machine_LSA-ppl" -problem $true -comment "OS is not supporting LSA protection (PPL)." 
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Authentication" -checkName "LSA Protection - PPL" -checkID "machine_LSA-ppl" -status $csvOp -finding "OS is not supporting LSA protection (PPL)." 
     }
 }
 
@@ -869,24 +878,24 @@ function checkInternetAccess{
             writeToFile -file $outputFile -path $folderLocation -str " > DNS request to 8.8.8.8 DNS server was successful. This may be considered a finding, at least on servers."
             writeToFile -file $outputFile -path $folderLocation -str " > DNS request output: "
             writeToFile -file $outputFile -path $folderLocation -str ($test | Out-String)
-            addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - DNS" -checkID "machine_na-dns" -problem $true -comment "Public DNS is accessible." 
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - DNS" -checkID "machine_na-dns" -status $csvOp -finding "Public DNS is accessible." 
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > DNS request to 8.8.8.8 DNS server received a timeout. This is generally good - direct access to internet DNS isn't allowed."
-            addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - DNS" -checkID "machine_na-dns" -problem $false -comment "Public DNS is not accessible." 
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - DNS" -checkID "machine_na-dns" -status $csvSt -finding "Public DNS is not accessible." 
         }
     }
     else{
         $result = nslookup google.com 8.8.8.8
         if ($result -like "*DNS request timed out*"){
             writeToFile -file $outputFile -path $folderLocation -str " > DNS request to 8.8.8.8 DNS server received a timeout. This is generally good - direct access to internet DNS isn't allowed."
-            addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - DNS" -checkID "machine_na-dns" -problem $false -comment "Public DNS is not accessible." 
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - DNS" -checkID "machine_na-dns" -status $csvSt -finding "Public DNS is not accessible." 
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > DNS request to 8.8.8.8 DNS server didn't receive a timeout. This may be considered a finding, at least on servers."
             writeToFile -file $outputFile -path $folderLocation -str " > DNS request output: "
             writeToFile -file $outputFile -path $folderLocation -str ($result | Out-String)
-            addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - DNS" -checkID "machine_na-dns" -problem $true -comment "Public DNS is accessible." 
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - DNS" -checkID "machine_na-dns" -status $csvOp -finding "Public DNS is accessible." 
         }
     }
     if($psVer -ge 4){
@@ -993,22 +1002,22 @@ function checkInternetAccess{
             $naOutput += "; Port 8080: Blocked"
         }
         if($naStdPorts -and $naNStdPorts){
-            addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -problem $true -comment "All ports are open for this machine: $naOutput." 
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -status $csvOp -finding "All ports are open for this machine: $naOutput." 
         }
         elseif ($naStdPorts){
-            addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -problem "UNKNOWN" -comment "Standard ports (e.g., 80,443) are open for this machine (bad for servers ok for workstations): $naOutput." 
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -status $csvUn -finding "Standard ports (e.g., 80,443) are open for this machine (bad for servers ok for workstations): $naOutput." 
         }
         elseif ($naNStdPorts){
-            addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -problem $true -comment "None standard ports are open (maybe miss configuration?) for this machine (bad for servers ok for workstations): $naOutput." 
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -status $csvOp -finding "None standard ports are open (maybe miss configuration?) for this machine (bad for servers ok for workstations): $naOutput." 
         }
         else{
-            addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -problem $false -comment "All browsing ports seem to be closed: $naOutput." 
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -status $csvSt -finding "All browsing ports seem to be closed: $naOutput." 
         }
     }
     else{
         writeToFile -file $outputFile -path $folderLocation -str "PowerShell is lower then version 4. Other checks are not supported."
         writeToLog -str "Function checkInternetAccess: PowerShell executing the script does not support curl command. Skipping network connection test."
-        addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -problem "UNKNOWN" -comment "PowerShell executing the script does not support curl command. (e.g., PSv3 and below)." 
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -status $csvUn -finding "PowerShell executing the script does not support curl command. (e.g., PSv3 and below)." 
     }
     <#
     # very long test - skipping it for now 
@@ -1035,12 +1044,12 @@ function checkSMBHardening {
         if ($SMB1.SMB1 -eq 0)
             {
                 writeToFile -file $outputFile -path $folderLocation -str "SMB1 Server is not supported (based on registry values). Which is nice." 
-                addToCSV -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB1" -checkID "domain_SMBv1" -problem $false -comment "SMB1 Server is not supported." 
+                addToCSV -relatedFile $outputFile -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB1" -checkID "domain_SMBv1" -status $csvSt -finding "SMB1 Server is not supported." 
             }
         else
             {
                 writeToFile -file $outputFile -path $folderLocation -str "SMB1 Server is supported (based on registry values). Which is pretty bad and a finding." 
-                addToCSV -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB1" -checkID "domain_SMBv1" -problem $true -comment "SMB1 Server is supported (based on registry values)." 
+                addToCSV -relatedFile $outputFile -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB1" -checkID "domain_SMBv1" -status $csvOp -finding "SMB1 Server is supported (based on registry values)." 
             }
         # unknown var will all return false always
         <#
@@ -1053,12 +1062,12 @@ function checkSMBHardening {
         if ($SMB2.SMB2 -eq 0)
             {
                 writeToFile -file $outputFile -path $folderLocation -str "SMB2 and SMB3 Server are not supported (based on registry values). Which is weird, but not a finding." 
-                addToCSV -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB2-3" -checkID "domain_SMBv2-3-reg" -problem $true -comment "SMB2 and SMB3 Server are not supported (based on registry values)." 
+                addToCSV -relatedFile $outputFile -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB2-3" -checkID "domain_SMBv2-3-reg" -status $csvOp -finding "SMB2 and SMB3 Server are not supported (based on registry values)." 
             }
         else
             {
                 writeToFile -file $outputFile -path $folderLocation -str "SMB2 and SMB3 Server are supported (based on registry values). Which is OK."
-                addToCSV -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB2-3" -checkID "domain_SMBv2-3-reg" -problem $false -comment "SMB2 and SMB3 Server are supported." 
+                addToCSV -relatedFile $outputFile -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB2-3" -checkID "domain_SMBv2-3-reg" -status $csvSt -finding "SMB2 and SMB3 Server are supported." 
              }
         if($psVer -ge 4){
             $smbServerConfig = Get-SmbServerConfiguration
@@ -1066,12 +1075,12 @@ function checkSMBHardening {
             if (!$smbServerConfig.EnableSMB2Protocol)
                 {
                     writeToFile -file $outputFile -path $folderLocation -str "SMB2 Server is not supported (based on Get-SmbServerConfiguration). Which is weird, but not a finding." 
-                    addToCSV -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB2-3" -checkID "domain_SMBv2-3-PS" -problem $true -comment "SMB2 Server is not supported (based on powershell)." 
+                    addToCSV -relatedFile $outputFile -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB2-3" -checkID "domain_SMBv2-3-PS" -status $csvOp -finding "SMB2 Server is not supported (based on powershell)." 
                 }
             else
                 {
                     writeToFile -file $outputFile -path $folderLocation -str "SMB2 Server is supported (based on Get-SmbServerConfiguration). Which is OK." 
-                    addToCSV -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB2-3" -checkID "domain_SMBv2-3-PS" -problem $false -comment "SMB2 Server is supported." 
+                    addToCSV -relatedFile $outputFile -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB2-3" -checkID "domain_SMBv2-3-PS" -status $csvSt -finding "SMB2 Server is supported." 
                 }
         }
         
@@ -1080,7 +1089,7 @@ function checkSMBHardening {
     {
         writeToFile -file $outputFile -path $folderLocation -str "Old Windows versions (XP or 2003) support only SMB1." 
         writeToLog -str "Function checkSMBHardening: unable to run windows too old"
-        addToCSV -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB2-3" -checkID "domain_SMBv2-3-PS" -problem $true -comment "Old Windows versions (XP or 2003) support only SMB1." 
+        addToCSV -relatedFile $outputFile -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB2-3" -checkID "domain_SMBv2-3-PS" -status $csvOp -finding "Old Windows versions (XP or 2003) support only SMB1." 
     }
     writeToFile -file $outputFile -path $folderLocation -str "============= SMB versions Support (Client Settings) ============="
     # Check if Windows Vista/2008 or above
@@ -1091,30 +1100,30 @@ function checkSMBHardening {
         {
             "0" {
                 writeToFile -file $outputFile -path $folderLocation -str "SMB1 Client is set to 'Boot'. Which is weird. Disabled is better." 
-                addToCSV -category "Domain Hardening - SMB" -checkName "SMB1 - Client" -checkID "domain_SMBv1-client" -problem $true -comment "SMB1 Client is set to 'Boot'." 
+                addToCSV -relatedFile $outputFile -category "Domain Hardening - SMB" -checkName "SMB1 - Client" -checkID "domain_SMBv1-client" -status $csvOp -finding "SMB1 Client is set to 'Boot'." 
             }
             "1" {
                 writeToFile -file $outputFile -path $folderLocation -str "SMB1 Client is set to 'System'. Which is not weird. although disabled is better."
-                addToCSV -category "Domain Hardening - SMB" -checkName "SMB1 - Client" -checkID "domain_SMBv1-client" -problem $true -comment "SMB1 Client is set to 'System'." 
+                addToCSV -relatedFile $outputFile -category "Domain Hardening - SMB" -checkName "SMB1 - Client" -checkID "domain_SMBv1-client" -status $csvOp -finding "SMB1 Client is set to 'System'." 
             }
             "2" {
                 writeToFile -file $outputFile -path $folderLocation -str "SMB1 Client is set to 'Automatic' (Enabled). Which is not very good, a possible finding, but not a must."
-                addToCSV -category "Domain Hardening - SMB" -checkName "SMB1 - Client" -checkID "domain_SMBv1-client" -problem $true -comment "SMB1 Client is set to 'Automatic' (Enabled)." 
+                addToCSV -relatedFile $outputFile -category "Domain Hardening - SMB" -checkName "SMB1 - Client" -checkID "domain_SMBv1-client" -status $csvOp -finding "SMB1 Client is set to 'Automatic' (Enabled)." 
             }
             "3" {
                 writeToFile -file $outputFile -path $folderLocation -str "SMB1 Client is set to 'Manual' (Turned off, but can be started). Which is pretty good, although disabled is better."
-                addToCSV -category "Domain Hardening - SMB" -checkName "SMB1 - Client" -checkID "domain_SMBv1-client" -problem $false -comment "SMB1 Client is set to 'Manual' (Turned off, but can be started)." 
+                addToCSV -relatedFile $outputFile -category "Domain Hardening - SMB" -checkName "SMB1 - Client" -checkID "domain_SMBv1-client" -status $csvSt -finding "SMB1 Client is set to 'Manual' (Turned off, but can be started)." 
             }
             "4" {
                 writeToFile -file $outputFile -path $folderLocation -str "SMB1 Client is set to 'Disabled'. Which is nice."
-                addToCSV -category "Domain Hardening - SMB" -checkName "SMB1 - Client" -checkID "domain_SMBv1-client" -problem $false -comment "SMB1 Client is set to 'Disabled'." 
+                addToCSV -relatedFile $outputFile -category "Domain Hardening - SMB" -checkName "SMB1 - Client" -checkID "domain_SMBv1-client" -status $csvSt -finding "SMB1 Client is set to 'Disabled'." 
             }
         }
     }
     else
     {
         writeToFile -file $outputFile -path $folderLocation -str "Old Windows versions (XP or 2003) support only SMB1."
-        addToCSV -category "Domain Hardening - SMB" -checkName "SMB1 - Client" -checkID "domain_SMBv1-client" -problem $true -comment "Old Windows versions (XP or 2003) support only SMB1." 
+        addToCSV -relatedFile $outputFile -category "Domain Hardening - SMB" -checkName "SMB1 - Client" -checkID "domain_SMBv1-client" -status $csvOp -finding "Old Windows versions (XP or 2003) support only SMB1." 
     }
     writeToFile -file $outputFile -path $folderLocation -str "============= SMB Signing (Server Settings) ============="
     $SmbServerRequireSigning = getRegValue -HKLM $true -regPath "\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters" -regName "RequireSecuritySignature"
@@ -1123,7 +1132,7 @@ function checkSMBHardening {
     {
         writeToFile -file $outputFile -path $folderLocation -str "Microsoft network server: Digitally sign communications (always) = Enabled"
         writeToFile -file $outputFile -path $folderLocation -str "SMB signing is required by the server, Which is good." 
-        addToCSV -category "Domain Hardening - SMB" -checkName "SMB2 - Server signing" -checkID "domain_SMBv1-srvSign" -problem $false -comment "SMB signing is required by the server." 
+        addToCSV -relatedFile $outputFile -category "Domain Hardening - SMB" -checkName "SMB2 - Server signing" -checkID "domain_SMBv1-srvSign" -status $csvSt -finding "SMB signing is required by the server." 
 
     }
     else
@@ -1133,14 +1142,14 @@ function checkSMBHardening {
             writeToFile -file $outputFile -path $folderLocation -str "Microsoft network server: Digitally sign communications (always) = Disabled" 
             writeToFile -file $outputFile -path $folderLocation -str "Microsoft network server: Digitally sign communications (if client agrees) = Enabled"
             writeToFile -file $outputFile -path $folderLocation -str "SMB signing is enabled by the server, but not required. Clients of this server are susceptible to man-in-the-middle attacks, if they don't require signing. A possible finding."
-            addToCSV -category "Domain Hardening - SMB" -checkName "SMB2 - Server signing" -checkID "domain_SMBv1-srvSign" -problem $true -comment "SMB signing is enabled by the server, but not required." 
+            addToCSV -relatedFile $outputFile -category "Domain Hardening - SMB" -checkName "SMB2 - Server signing" -checkID "domain_SMBv1-srvSign" -status $csvOp -finding "SMB signing is enabled by the server, but not required." 
         }
         else
         {
             writeToFile -file $outputFile -path $folderLocation -str "Microsoft network server: Digitally sign communications (always) = Disabled." 
             writeToFile -file $outputFile -path $folderLocation -str "Microsoft network server: Digitally sign communications (if client agrees) = Disabled." 
             writeToFile -file $outputFile -path $folderLocation -str "SMB signing is disabled by the server. Clients of this server are susceptible to man-in-the-middle attacks. A finding." 
-            addToCSV -category "Domain Hardening - SMB" -checkName "SMB2 - Server signing" -checkID "domain_SMBv1-srvSign" -problem $true -comment "SMB signing is disabled by the server." 
+            addToCSV -relatedFile $outputFile -category "Domain Hardening - SMB" -checkName "SMB2 - Server signing" -checkID "domain_SMBv1-srvSign" -status $csvOp -finding "SMB signing is disabled by the server." 
         }
     }
     # potentially, we can also check SMB signing configuration using PowerShell:
@@ -1157,7 +1166,7 @@ function checkSMBHardening {
     {
         writeToFile -file $outputFile -path $folderLocation -str "Microsoft network client: Digitally sign communications (always) = Enabled"
         writeToFile -file $outputFile -path $folderLocation -str "SMB signing is required by the client, Which is good." 
-        addToCSV -category "Domain Hardening - SMB" -checkName "SMB2 - Client signing" -checkID "domain_SMBv1-clientSign" -problem $false -comment "SMB signing is required by the client" 
+        addToCSV -relatedFile $outputFile -category "Domain Hardening - SMB" -checkName "SMB2 - Client signing" -checkID "domain_SMBv1-clientSign" -status $csvSt -finding "SMB signing is required by the client" 
     }
     else
     {
@@ -1166,14 +1175,14 @@ function checkSMBHardening {
             writeToFile -file $outputFile -path $folderLocation -str "Microsoft network client: Digitally sign communications (always) = Disabled" 
             writeToFile -file $outputFile -path $folderLocation -str "Microsoft network client: Digitally sign communications (if client agrees) = Enabled"
             writeToFile -file $outputFile -path $folderLocation -str "SMB signing is enabled by the client, but not required. This computer is susceptible to man-in-the-middle attacks against servers that don't require signing. A possible finding."
-            addToCSV -category "Domain Hardening - SMB" -checkName "SMB2 - Client signing" -checkID "domain_SMBv1-clientSign" -problem $true -comment "SMB signing is enabled by the client, but not required." 
+            addToCSV -relatedFile $outputFile -category "Domain Hardening - SMB" -checkName "SMB2 - Client signing" -checkID "domain_SMBv1-clientSign" -status $csvOp -finding "SMB signing is enabled by the client, but not required." 
         }
         else
         {
             writeToFile -file $outputFile -path $folderLocation -str "Microsoft network client: Digitally sign communications (always) = Disabled." 
             writeToFile -file $outputFile -path $folderLocation -str "Microsoft network client: Digitally sign communications (if client agrees) = Disabled." 
             writeToFile -file $outputFile -path $folderLocation -str "SMB signing is disabled by the client. This computer is susceptible to man-in-the-middle attacks. A finding."
-            addToCSV -category "Domain Hardening - SMB" -checkName "SMB2 - Client signing" -checkID "domain_SMBv1-clientSign" -problem $true -comment "SMB signing is disabled by the client." 
+            addToCSV -relatedFile $outputFile -category "Domain Hardening - SMB" -checkName "SMB2 - Client signing" -checkID "domain_SMBv1-clientSign" -status $csvOp -finding "SMB signing is disabled by the client." 
         }
     }
     if ($psVer -ge 4 -and($null -ne $smbServerConfig) -and ($null -ne $smbClientConfig)) {
@@ -1209,11 +1218,11 @@ function checkRDPSecurity {
     if($null -ne $reg -and $reg.fDenyTSConnections -eq 1)
     {
         writeToFile -file $outputFile -path $folderLocation -str " > RDP Is disabled on this machine."
-        addToCSV -category "Machine Hardening - RDP" -checkName "RDP Status" -checkID "machine_RDP-reg" -problem $false -comment "RDP Is disabled on this machine." 
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - RDP" -checkName "RDP Status" -checkID "machine_RDP-reg" -status $csvSt -finding "RDP Is disabled on this machine." 
     }
     else{
         writeToFile -file $outputFile -path $folderLocation -str " > RDP Is enabled on this machine."
-        addToCSV -category "Machine Hardening - RDP" -checkName "RDP Status" -checkID "machine_RDP-reg" -problem $false -comment "RDP Is enabled on this machine." 
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - RDP" -checkName "RDP Status" -checkID "machine_RDP-reg" -finding "RDP Is enabled on this machine." 
 
     }
     writeToFile -file $outputFile -path $folderLocation -str "============= Remote Desktop Users ============="
@@ -1246,7 +1255,7 @@ function checkRDPSecurity {
                 $rdpAdmins = $true
             }
             else{
-                $rdpUsers += line
+                $rdpUsers += $line
                 writeToFile -file $outputFile -path $folderLocation -str " > $line"
             }
         }
@@ -1256,52 +1265,52 @@ function checkRDPSecurity {
         }
     }
     if($rdpGenUsersFlag -and $rdpAdmins){
-        addToCSV -category "Machine Hardening - RDP" -checkName "RDP Allowed Users" -checkID "machine_RDP-Users" -problem $true -comment "RDP Allowed users is highly permissive: $rdpGenUsersStr additionally local admin are allows to remotely login the rest of the allowed RDP list (not including default groups like administrators):$rdpUsers." 
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - RDP" -checkName "RDP Allowed Users" -checkID "machine_RDP-Users" -status $csvOp -finding "RDP Allowed users is highly permissive: $rdpGenUsersStr additionally local admin are allows to remotely login the rest of the allowed RDP list (not including default groups like administrators):$rdpUsers." 
     }
     elseif($rdpGenUsersFlag){
-        addToCSV -category "Machine Hardening - RDP" -checkName "RDP Allowed Users" -checkID "machine_RDP-Users" -problem $true -comment "RDP Allowed users is highly permissive: $rdpGenUsersStr rest of the allowed RDP list(not including default groups like administrators):$rdpUsers." 
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - RDP" -checkName "RDP Allowed Users" -checkID "machine_RDP-Users" -status $csvOp -finding "RDP Allowed users is highly permissive: $rdpGenUsersStr rest of the allowed RDP list(not including default groups like administrators):$rdpUsers." 
     }
     elseif($rdpAdmins){
-        addToCSV -category "Machine Hardening - RDP" -checkName "RDP Allowed Users" -checkID "machine_RDP-Users" -problem $true -comment "Local admin are allows to remotely login the the allowed RDP users and groups list(not including default groups like administrators):$rdpUsers." 
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - RDP" -checkName "RDP Allowed Users" -checkID "machine_RDP-Users" -status $csvOp -finding "Local admin are allows to remotely login the the allowed RDP users and groups list(not including default groups like administrators):$rdpUsers." 
     }
     else{
-        addToCSV -category "Machine Hardening - RDP" -checkName "RDP Allowed Users" -checkID "machine_RDP-Users" -problem "UNKNOWN" -comment "Allowed RDP users and groups list(not including default groups like administrators):$rdpUsers." 
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - RDP" -checkName "RDP Allowed Users" -checkID "machine_RDP-Users" -status $csvUn -finding "Allowed RDP users and groups list(not including default groups like administrators):$rdpUsers." 
     }
      
     writeToFile -file $outputFile -path $folderLocation -str "============= NLA (Network Level Authentication) ============="
     if ($RDP.UserAuthenticationRequired -eq 1)
         {
             writeToFile -file $outputFile -path $folderLocation -str "NLA is required, which is fine."
-            addToCSV -category "Machine Hardening - RDP" -checkName "RDP - Network Level Authentication" -checkID "machine_RDP-NLA" -problem $false -comment "NLA is required." 
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - RDP" -checkName "RDP - Network Level Authentication" -checkID "machine_RDP-NLA" -status $csvSt -finding "NLA is required." 
         }
     if ($RDP.UserAuthenticationRequired -eq 0)
         {
             writeToFile -file $outputFile -path $folderLocation -str "NLA is not required, which is bad. A possible finding."
-            addToCSV -category "Machine Hardening - RDP" -checkName "RDP - Network Level Authentication" -checkID "machine_RDP-NLA" -problem $true -comment "NLA is not required." 
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - RDP" -checkName "RDP - Network Level Authentication" -checkID "machine_RDP-NLA" -status $csvOp -finding "NLA is not required." 
 
         }
         writeToFile -file $outputFile -path $folderLocation -str "============= Security Layer (SSL/TLS) ============="
     if ($RDP.SecurityLayer -eq 0)
         {
             writeToFile -file $outputFile -path $folderLocation -str "Native RDP encryption is used instead of SSL/TLS, which is bad. A possible finding."
-            addToCSV -category "Machine Hardening - RDP" -checkName "RDP - Security Layer (SSL/TLS)" -checkID "machine_RDP-TLS" -problem $true -comment "Native RDP encryption is used instead of SSL/TLS." 
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - RDP" -checkName "RDP - Security Layer (SSL/TLS)" -checkID "machine_RDP-TLS" -status $csvOp -finding "Native RDP encryption is used instead of SSL/TLS." 
          }
     if ($RDP.SecurityLayer -eq 1)
         {
             writeToFile -file $outputFile -path $folderLocation -str "SSL/TLS is supported, but not required ('Negotiate' setting). Which is not recommended, but not necessary a finding."
-            addToCSV -category "Machine Hardening - RDP" -checkName "RDP - Security Layer (SSL/TLS)" -checkID "machine_RDP-TLS" -problem $true -comment "SSL/TLS is supported, but not required." 
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - RDP" -checkName "RDP - Security Layer (SSL/TLS)" -checkID "machine_RDP-TLS" -status $csvOp -finding "SSL/TLS is supported, but not required." 
         }
     if ($RDP.SecurityLayer -eq 2)
         {
             writeToFile -file $outputFile -path $folderLocation -str "SSL/TLS is required for connecting. Which is good."
-            addToCSV -category "Machine Hardening - RDP" -checkName "RDP - Security Layer (SSL/TLS)" -checkID "machine_RDP-TLS" -problem $false -comment "SSL/TLS is required for connecting." 
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - RDP" -checkName "RDP - Security Layer (SSL/TLS)" -checkID "machine_RDP-TLS" -status $csvSt -finding "SSL/TLS is required for connecting." 
         }
         writeToFile -file $outputFile -path $folderLocation -str "============= Raw RDP Timeout Settings (from Registry) ============="
     $RDPTimeout = Get-Item "HKLM:\Software\Policies\Microsoft\Windows NT\Terminal Services"
     if ($RDPTimeout.ValueCount -eq 0)
         {
             writeToFile -file $outputFile -path $folderLocation -str "RDP timeout is not configured. A possible finding."
-            addToCSV -category "Machine Hardening - RDP" -checkName "RDP - Timeout" -checkID "machine_RDP-Timeout" -problem $true -comment "RDP timeout is not configured." 
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - RDP" -checkName "RDP - Timeout" -checkID "machine_RDP-Timeout" -status $csvOp -finding "RDP timeout is not configured." 
 
     }
     else
@@ -1314,7 +1323,7 @@ function checkRDPSecurity {
         writeToFile -file $outputFile -path $folderLocation -str "fResetBroken = Log off session (instead of disconnect) when time limits are reached" 
         writeToFile -file $outputFile -path $folderLocation -str "60000 = 1 minute, 3600000 = 1 hour, etc."
         writeToFile -file $outputFile -path $folderLocation -str "`r`nFor further information, see the GPO settings at: Computer Configuration\Administrative Templates\Windows Components\Remote Desktop Services\Remote Desktop Session\Session Time Limits"
-        addToCSV -category "Machine Hardening - RDP" -checkName "RDP - Timeout" -checkID "machine_RDP-Timeout" -problem $false -comment "RDP timeout is configured - Check manual file to find specific configuration" 
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - RDP" -checkName "RDP - Timeout" -checkID "machine_RDP-Timeout" -status $csvSt -finding "RDP timeout is configured - Check manual file to find specific configuration" 
     } 
     writeToFile -file $outputFile -path $folderLocation -str "============= Raw RDP Settings (from WMI) ============="
     writeToFile -file $outputFile -path $folderLocation -str ($RDP | Format-List Terminal*,*Encrypt*, Policy*,Security*,SSL*,*Auth* | Out-String )
@@ -1387,7 +1396,7 @@ function checkAntiVirusStatus {
         if ($null -eq $AntiVirusProducts)
             {
                 writeToFile -file $outputFile -path $folderLocation -str "No Anti Virus products were found."
-                addToCSV -category "Machine Hardening - Security" -checkName "AntiVirus installed system" -checkID "machine_AVName" -problem $true -comment "No AntiVirus detected on machine."  
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Security" -checkName "AntiVirus installed system" -checkID "machine_AVName" -status $csvOp -finding "No AntiVirus detected on machine."  
             }
         writeToFile -file $outputFile -path $folderLocation -str "============= Antivirus Products Status ============="
         $sumOutput = ""
@@ -1419,16 +1428,16 @@ function checkAntiVirusStatus {
         }
         if($sumOutput -ne ""){
             if($outOfDateAV -and $notEnabledAV){
-                addToCSV -category "Machine Hardening - Security" -checkName "AntiVirus installed system" -checkID "machine_AVName" -problem $true -comment "AntiVirus is not enabled and not up to date `n $sumOutput."  
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Security" -checkName "AntiVirus installed system" -checkID "machine_AVName" -status $csvOp -finding "AntiVirus is not enabled and not up to date `n $sumOutput."  
             }
             elseif ($outOfDateAV) {
-                addToCSV -category "Machine Hardening - Security" -checkName "AntiVirus installed system" -checkID "machine_AVName" -problem $true -comment "AntiVirus is not up to date `n $sumOutput."  
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Security" -checkName "AntiVirus installed system" -checkID "machine_AVName" -status $csvOp -finding "AntiVirus is not up to date `n $sumOutput."  
             }
             elseif ($notEnabledAV){
-                addToCSV -category "Machine Hardening - Security" -checkName "AntiVirus installed system" -checkID "machine_AVName" -problem $true -comment "AntiVirus is not enabled `n $sumOutput."  
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Security" -checkName "AntiVirus installed system" -checkID "machine_AVName" -status $csvOp -finding "AntiVirus is not enabled `n $sumOutput."  
             }
             else{
-                addToCSV -category "Machine Hardening - Security" -checkName "AntiVirus installed system" -checkID "machine_AVName" -problem $false -comment "AntiVirus is up to date and enabled `n $sumOutput."  
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Security" -checkName "AntiVirus installed system" -checkID "machine_AVName" -status $csvSt -finding "AntiVirus is up to date and enabled `n $sumOutput."  
             }
         }
         
@@ -1509,13 +1518,13 @@ function checkLLMNRAndNetBIOS {
     if ($LLMNR_Enabled -eq 0)
         {
             writeToFile -file $outputFile -path $folderLocation -str "LLMNR is disabled, which is secure."
-            addToCSV -category "Domain Hardening - Network" -checkName "LLMNR" -checkID "domain_LLMNR" -problem $false -comment "LLMNR is disabled, which is secure."  
+            addToCSV -relatedFile $outputFile -category "Domain Hardening - Network" -checkName "LLMNR" -checkID "domain_LLMNR" -status $csvSt -finding "LLMNR is disabled, which is secure."  
 
     }
     else
         {
             writeToFile -file $outputFile -path $folderLocation -str "LLMNR is enabled, which is a finding, especially for workstations."
-            addToCSV -category "Domain Hardening - Network" -checkName "LLMNR" -checkID "domain_LLMNR" -problem $true -comment "LLMNR is enabled."  
+            addToCSV -relatedFile $outputFile -category "Domain Hardening - Network" -checkName "LLMNR" -checkID "domain_LLMNR" -status $csvOp -finding "LLMNR is enabled."  
 
         }
         writeToFile -file $outputFile -path $folderLocation -str "============= NETBIOS Name Service Configuration ============="
@@ -1525,7 +1534,7 @@ function checkLLMNRAndNetBIOS {
     if ($NodeType -eq 2)
         {
             writeToFile -file $outputFile -path $folderLocation -str "NetBIOS Node Type is set to P-node (only point-to-point name queries to a WINS name server), which is secure."
-            addToCSV -category "Domain Hardening - Network" -checkName "NetBIOS Node type" -checkID "domain_NetBIOSNT" -problem $false -comment "NetBIOS Node Type is set to P-node (only point-to-point name queries to a WINS name server)"  
+            addToCSV -relatedFile $outputFile -category "Domain Hardening - Network" -checkName "NetBIOS Node type" -checkID "domain_NetBIOSNT" -status $csvSt -finding "NetBIOS Node Type is set to P-node (only point-to-point name queries to a WINS name server)"  
         }
     else
     {
@@ -1533,19 +1542,19 @@ function checkLLMNRAndNetBIOS {
         {
             $null {
                 writeToFile -file $outputFile -path $folderLocation -str "NetBIOS Node Type is set to the default setting (broadcast queries), which is not secure and a finding."
-                addToCSV -category "Domain Hardening - Network" -checkName "NetBIOS Node type" -checkID "domain_NetBIOSNT" -problem $true -comment "NetBIOS Node Type is set to the default setting (broadcast queries)."  
+                addToCSV -relatedFile $outputFile -category "Domain Hardening - Network" -checkName "NetBIOS Node type" -checkID "domain_NetBIOSNT" -status $csvOp -finding "NetBIOS Node Type is set to the default setting (broadcast queries)."  
             }
             1 {
                 writeToFile -file $outputFile -path $folderLocation -str "NetBIOS Node Type is set to B-node (broadcast queries), which is not secure and a finding."
-                addToCSV -category "Domain Hardening - Network" -checkName "NetBIOS Node type" -checkID "domain_NetBIOSNT" -problem $true -comment "NetBIOS Node Type is set to B-node (broadcast queries)."  
+                addToCSV -relatedFile $outputFile -category "Domain Hardening - Network" -checkName "NetBIOS Node type" -checkID "domain_NetBIOSNT" -status $csvOp -finding "NetBIOS Node Type is set to B-node (broadcast queries)."  
             }
             4 {
                 writeToFile -file $outputFile -path $folderLocation -str "NetBIOS Node Type is set to M-node (broadcasts first, then queries the WINS name server), which is not secure and a finding."
-                addToCSV -category "Domain Hardening - Network" -checkName "NetBIOS Node type" -checkID "domain_NetBIOSNT" -problem $true -comment "NetBIOS Node Type is set to M-node (broadcasts first, then queries the WINS name server)."  
+                addToCSV -relatedFile $outputFile -category "Domain Hardening - Network" -checkName "NetBIOS Node type" -checkID "domain_NetBIOSNT" -status $csvOp -finding "NetBIOS Node Type is set to M-node (broadcasts first, then queries the WINS name server)."  
             }
             8 {
                 writeToFile -file $outputFile -path $folderLocation -str "NetBIOS Node Type is set to H-node (queries the WINS name server first, then broadcasts), which is not secure and a finding."
-                addToCSV -category "Domain Hardening - Network" -checkName "NetBIOS Node type" -checkID "domain_NetBIOSNT" -problem $true -comment "NetBIOS Node Type is set to H-node (queries the WINS name server first, then broadcasts)."  
+                addToCSV -relatedFile $outputFile -category "Domain Hardening - Network" -checkName "NetBIOS Node type" -checkID "domain_NetBIOSNT" -status $csvOp -finding "NetBIOS Node Type is set to H-node (queries the WINS name server first, then broadcasts)."  
             }        
         }
 
@@ -1581,7 +1590,7 @@ function checkWDigest {
         if (($winVersion.Major -ge 10) -or (($winVersion.Major -eq 6) -and ($winVersion.Minor -eq 3)))
             {
                 writeToFile -file $outputFile -path $folderLocation -str  "The WDigest protocol is turned off by default for Win8.1/2012R2 and above. So it is OK, but still recommended to set the UseLogonCredential registry value to 0, to revert malicious attempts of enabling WDigest."
-                addToCSV -category "Domain Hardening - Authentication" -checkName "WDigest Clear-Text passwords in LSAS" -checkID "domain_WDigest" -problem $false -comment "The WDigest protocol is turned off by default for Win8.1/2012R2 and above."  
+                addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "WDigest Clear-Text passwords in LSASS" -checkID "domain_WDigest" -status $csvSt -finding "The WDigest protocol is turned off by default for Win8.1/2012R2 and above."  
             }
         else
         {
@@ -1589,13 +1598,13 @@ function checkWDigest {
             if (($winVersion.Major -eq 6) -and ($winVersion.Minor -ge 1))    
                 {
                     writeToFile -file $outputFile -path $folderLocation -str "WDigest stores cleartext user credentials in memory by default in Win7/2008/8/2012. A possible finding."
-                    addToCSV -category "Domain Hardening - Authentication" -checkName "WDigest Clear-Text passwords in LSAS" -checkID "domain_WDigest" -problem $true -comment "WDigest stores cleartext user credentials in memory by default in Win7/2008/8/2012."  
+                    addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "WDigest Clear-Text passwords in LSASS" -checkID "domain_WDigest" -status $csvOp -finding "WDigest stores cleartext user credentials in memory by default in Win7/2008/8/2012."  
                 }
             else
             {
                 writeToFile -file $outputFile -path $folderLocation -str "The operating system version is not supported. You have worse problems than WDigest configuration."
                 writeToFile -file $outputFile -path $folderLocation -str "WDigest stores cleartext user credentials in memory by default, but this configuration cannot be hardened since it is a legacy OS."
-                addToCSV -category "Domain Hardening - Authentication" -checkName "WDigest Clear-Text passwords in LSAS" -checkID "domain_WDigest" -problem $true -comment "WDigest stores cleartext user credentials in memory by default, but this configuration cannot be hardened since it is a legacy OS."  
+                addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "WDigest Clear-Text passwords in LSASS" -checkID "domain_WDigest" -status $csvOp -finding "WDigest stores cleartext user credentials in memory by default, but this configuration cannot be hardened since it is a legacy OS."  
 
             }
         }
@@ -1606,14 +1615,14 @@ function checkWDigest {
         {
             writeToFile -file $outputFile -path $folderLocation -str "WDigest UseLogonCredential registry key set to 0."
             writeToFile -file $outputFile -path $folderLocation -str "WDigest doesn't store cleartext user credentials in memory, which is good. The setting was intentionally hardened."
-            addToCSV -category "Domain Hardening - Authentication" -checkName "WDigest Clear-Text passwords in LSAS" -checkID "domain_WDigest" -problem $false -comment "WDigest doesn't store cleartext user credentials in memory."  
+            addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "WDigest Clear-Text passwords in LSASS" -checkID "domain_WDigest" -status $csvSt -finding "WDigest doesn't store cleartext user credentials in memory."  
 
         }
         if ($WDigest.UseLogonCredential -eq 1)
         {
             writeToFile -file $outputFile -path $folderLocation -str "WDigest UseLogonCredential registry key set to 1."
             writeToFile -file $outputFile -path $folderLocation -str "WDigest stores cleartext user credentials in memory, which is bad and a finding. The configuration was either intentionally configured by an admin for some reason, or was set by a threat actor to fetch clear-text credentials."
-            addToCSV -category "Domain Hardening - Authentication" -checkName "WDigest Clear-Text passwords in LSAS" -checkID "domain_WDigest" -problem $true -comment "WDigest stores cleartext user credentials in memory."  
+            addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "WDigest Clear-Text passwords in LSASS" -checkID "domain_WDigest" -status $csvOp -finding "WDigest stores cleartext user credentials in memory."  
         }
     }
     
@@ -1675,12 +1684,12 @@ function checkSAMEnum{
         if (($winVersion.Major -ge 10) -and ($winVersion.Build -ge 14393))
             {
                 writeToFile -file $outputFile -path $folderLocation -str "This OS version is hardened by default."
-                addToCSV -category "Domain Hardening - Enumeration" -checkName "SAM enumeration permissions" -checkID "domain_SAMEnum" -problem $false -comment "Using default settings - this OS version is hardened by default."
+                addToCSV -relatedFile $outputFile -category "Domain Hardening - Enumeration" -checkName "SAM enumeration permissions" -checkID "domain_SAMEnum" -status $csvSt -finding "Using default settings - this OS version is hardened by default."
         }
         else
             {
                 writeToFile -file $outputFile -path $folderLocation -str "This OS version is not hardened by default and this issue can be seen as a finding."
-                addToCSV -category "Domain Hardening - Enumeration" -checkName "SAM enumeration permissions" -checkID "domain_SAMEnum" -problem $true -comment "Using default settings - this OS version is not hardened by default."
+                addToCSV -relatedFile $outputFile -category "Domain Hardening - Enumeration" -checkName "SAM enumeration permissions" -checkID "domain_SAMEnum" -status $csvOp -finding "Using default settings - this OS version is not hardened by default."
             }
     }
     else
@@ -1690,7 +1699,7 @@ function checkSAMEnum{
         $RestrictRemoteSAMPermissions = ConvertFrom-SDDLString -Sddl $RestrictRemoteSAMValue
         writeToFile -file $outputFile -path $folderLocation -str "Below are the permissions for SAM enumeration. Make sure that only Administrators are granted Read permissions."
         writeToFile -file $outputFile -path $folderLocation -str ($RestrictRemoteSAMPermissions | Out-String)
-        addToCSV -category "Domain Hardening - Enumeration" -checkName "SAM enumeration permissions" -checkID "domain_SAMEnum" -problem "UNKNOWN" -comment "RestrictRemoteSAM configuration existing please go to the full result to make sure that only Administrators are granted Read permissions."
+        addToCSV -relatedFile $outputFile -category "Domain Hardening - Enumeration" -checkName "SAM enumeration permissions" -checkID "domain_SAMEnum" -status $csvUn -finding "RestrictRemoteSAM configuration existing please go to the full result to make sure that only Administrators are granted Read permissions."
     }
 }
 
@@ -1713,12 +1722,12 @@ function checkPowershellVer {
     {
         $temp = Start-Job {Get-Host} -PSVersion 2.0 -Name "PSv2Check"
         writeToFile -file $outputFile -path $folderLocation -str "PowerShell version 2 is installed and was able to run commands. This is a finding!"
-        addToCSV -category "Machine Hardening - Operation system" -checkName "Powershell version 2 support - 1" -checkID "machine_PSv2.1" -problem $true -comment "PowerShell version 2 is installed and was able to run commands."
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Operation system" -checkName "Powershell version 2 support - 1" -checkID "machine_PSv2.1" -status $csvOp -finding "PowerShell version 2 is installed and was able to run commands."
     }
     catch
     {
         writeToFile -file $outputFile -path $folderLocation -str "PowerShell version 2 was not able to run. This is secure."
-        addToCSV -category "Machine Hardening - Operation system" -checkName "Powershell version 2 support - 1" -checkID "machine_PSv2.1" -problem $false -comment "PowerShell version 2 was not able to run."
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Operation system" -checkName "Powershell version 2 support - 1" -checkID "machine_PSv2.1" -status $csvSt -finding "PowerShell version 2 was not able to run."
     }
     finally
     {
@@ -1774,12 +1783,12 @@ function checkPowershellVer {
     if (($LegacyPowerShell.PowerShellVersion -eq "2.0") -or ($LegacyPowerShell.PowerShellVersion -eq "1.0"))
     {
         writeToFile -file $outputFile -path $folderLocation -str ("PowerShell version " + $LegacyPowerShell.PowerShellVersion + " is installed, based on the registry value mentioned above.")
-        addToCSV -category "Machine Hardening - Operation system" -checkName "Powershell version 2 support - 2" -checkID "machine_PSv2.2" -problem $true -comment ("PowerShell version " + $LegacyPowerShell.PowerShellVersion + " is installed, based on the registry value.")
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Operation system" -checkName "Powershell version 2 support - 2" -checkID "machine_PSv2.2" -status $csvOp -finding ("PowerShell version " + $LegacyPowerShell.PowerShellVersion + " is installed, based on the registry value.")
     }
     else
     {
         writeToFile -file $outputFile -path $folderLocation -str "PowerShell version 1/2 is not installed." 
-        addToCSV -category "Machine Hardening - Operation system" -checkName "Powershell version 2 support - 2" -checkID "machine_PSv2.2" -problem $false -comment ("PowerShell version 1/2 is not installed.")
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Operation system" -checkName "Powershell version 2 support - 2" -checkID "machine_PSv2.2" -status $csvSt -finding ("PowerShell version 1/2 is not installed.")
     }
     
 }
@@ -1799,41 +1808,41 @@ function checkNTLMv2 {
     $temp = getRegValue -HKLM $true -regPath "\SYSTEM\CurrentControlSet\Control\Lsa" -regName "LmCompatibilityLevel"
     if(!($partOfDomain)){
         writeToFile -file $outputFile -path $folderLocation -str " > Machine is not part of a domain." #using system default depends on OS version
-        addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem $false -comment "Machine is not part of a domain."
+        addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -status $csvSt -finding "Machine is not part of a domain."
     }
     else{
         if($null -eq $temp){
             writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level Unknown) LM and NTLMv1 restriction does not exist - using OS default. On Windows 2008/7 and above, default is to send NTLMv2 only (Level 3), which is quite secure. `r`n" #using system default depends on OS version
-            addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem $false -comment "NTLM Authentication setting: (Level Unknown) LM and NTLMv1 restriction does not exist - using OS default. On Windows 2008/7 and above, default is to send NTLMv2 only (Level 3)."
+            addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -status $csvSt -finding "NTLM Authentication setting: (Level Unknown) LM and NTLMv1 restriction does not exist - using OS default. On Windows 2008/7 and above, default is to send NTLMv2 only (Level 3)."
         }
         switch ($temp.lmcompatibilitylevel) {
             (0) { 
                 writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 0) Send LM and NTLM response; never use NTLM 2 session security. Clients use LM and NTLM authentication, and never use NTLM 2 session security; domain controllers accept LM, NTLM, and NTLM 2 authentication. - this is a finding!`r`n"
-                addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem $true -comment "(Level 0) Send LM and NTLM response; never use NTLM 2 session security. Clients use LM and NTLM authentication, and never use NTLM 2 session security."
+                addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -status $csvOp -finding "(Level 0) Send LM and NTLM response; never use NTLM 2 session security. Clients use LM and NTLM authentication, and never use NTLM 2 session security."
             }
             (1) { 
                 writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 1) Use NTLM 2 session security if negotiated. Clients use LM and NTLM authentication, and use NTLM 2 session security if the server supports it; domain controllers accept LM, NTLM, and NTLM 2 authentication. - this is a finding!`r`n"
-                addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem $true -comment "(Level 1) Use NTLM 2 session security if negotiated. Clients use LM and NTLM authentication, and use NTLM 2 session security if the server supports it."
+                addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -status $csvOp -finding "(Level 1) Use NTLM 2 session security if negotiated. Clients use LM and NTLM authentication, and use NTLM 2 session security if the server supports it."
             }
             (2) { 
                 writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 2) Send NTLM response only. Clients use only NTLM authentication, and use NTLM 2 session security if the server supports it; domain controllers accept LM, NTLM, and NTLM 2 authentication. - this is a finding!`r`n"
-                addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem $true -comment "(Level 2) Send NTLM response only. Clients use only NTLM authentication, and use NTLM 2 session security if the server supports it."
+                addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -status $csvOp -finding "(Level 2) Send NTLM response only. Clients use only NTLM authentication, and use NTLM 2 session security if the server supports it."
             }
             (3) { 
                 writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 3) Send NTLM 2 response only. Clients use NTLM 2 authentication, and use NTLM 2 session security if the server supports it; domain controllers accept LM, NTLM, and NTLM 2 authentication. - Not a finding if all servers are with the same configuration.`r`n"
-                addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem $false -comment "(Level 3) Send NTLM 2 response only. Clients use NTLM 2 authentication, and use NTLM 2 session security if the server supports it."
+                addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -status $csvSt -finding "(Level 3) Send NTLM 2 response only. Clients use NTLM 2 authentication, and use NTLM 2 session security if the server supports it."
             }
             (4) { 
                 writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 4) Domain controllers refuse LM responses. Clients use NTLM authentication, and use NTLM 2 session security if the server supports it; domain controllers refuse LM authentication (that is, they accept NTLM and NTLM 2) - Not a finding if all servers are with the same configuration. If this is a DC, it means that LM is not applicable in the domain at all.`r`n"
-                addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem $false -comment "(Level 4) Domain controllers refuse LM responses. Clients use NTLM authentication, and use NTLM 2 session security if the server supports it."
+                addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -status $csvSt -finding "(Level 4) Domain controllers refuse LM responses. Clients use NTLM authentication, and use NTLM 2 session security if the server supports it."
             }
             (5) { 
                 writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 5) Domain controllers refuse LM and NTLM responses (accept only NTLM 2). Clients use NTLM 2 authentication, use NTLM 2 session security if the server supports it; domain controllers refuse NTLM and LM authentication (they accept only NTLM 2 - This is the most hardened configuration. If this is a DC, it means that NTLMv2 and LM are not applicable in the domain at all.)`r`n"
-                addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem $false -comment "(Level 5) Domain controllers refuse LM and NTLM responses (accept only NTLM 2). Clients use NTLM 2 authentication, use NTLM 2 session security if the server supports it."
+                addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -status $csvSt -finding "(Level 5) Domain controllers refuse LM and NTLM responses (accept only NTLM 2). Clients use NTLM 2 authentication, use NTLM 2 session security if the server supports it."
             }
             Default {
                 writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level Unknown) - " + $temp.lmcompatibilitylevel + "`r`n"
-                addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem "UNKNOWN" -comment ("(Level Unknown) - " + $temp.lmcompatibilitylevel +".")
+                addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -status $csvUn -finding ("(Level Unknown) - " + $temp.lmcompatibilitylevel +".")
 
             }
         }
@@ -1850,7 +1859,7 @@ function checkGPOReprocess {
     writeToLog -str "running checkGPOReprocess function"
     writeToScreen -str "Getting GPO reprocess configuration..." -ForegroundColor Yellow
     writeToFile -file $outputFile -path $folderLocation -str "`r`n============= GPO Reprocess Check ============="
-    writeToFile -file $outputFile -path $folderLocation -str "If GPO reprocess is not enabled, the GPO settings can be overridden locally by an admistrator. Upon the next gpupdate process, the GPO settings will not be reapplied, until the next GPO change."
+    writeToFile -file $outputFile -path $folderLocation -str "If GPO reprocess is not enabled, the GPO settings can be overridden locally by an administrator. Upon the next gpupdate process, the GPO settings will not be reapplied, until the next GPO change."
     writeToFile -file $outputFile -path $folderLocation -str "It is recommended that all security settings will be repossessed (reapplied) every time the system checks for GPO change, even if there were no GPO changes."
     writeToFile -file $outputFile -path $folderLocation -str "For more information, see: https://www.stigviewer.com/stig/windows_server_2012_member_server/2014-01-07/finding/V-4448`r`n"
     
@@ -1858,17 +1867,17 @@ function checkGPOReprocess {
     $temp = getRegValue -HKLM $true -regPath "\Software\Policies\Microsoft\Windows\Group Policy\{35378EAC-683F-11D2-A89A-00C04FBBCFA2}" -regName "NoGPOListChanges"
     if ($null -eq $temp) {
         writeToFile -file $outputFile -path $folderLocation -str ' > GPO registry policy reprocess is not configured - settings left as default. Can be considered a finding.'
-        addToCSV -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Registry policy" -checkID "domain_GPOReRegistry" -problem $false -comment "GPO registry policy reprocess is not configured - settings left as default."
+        addToCSV -relatedFile $outputFile -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Registry policy" -checkID "domain_GPOReRegistry" -status $csvSt -finding "GPO registry policy reprocess is not configured - settings left as default."
     }
     else {
         if ($temp.NoGPOListChanges -eq 0) {
             writeToFile -file $outputFile -path $folderLocation -str ' > GPO registry policy reprocess is enabled - this is the hardened configuration.'
-            addToCSV -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Registry policy" -checkID "domain_GPOReRegistry" -problem $false -comment "GPO registry policy reprocess is enabled."
+            addToCSV -relatedFile $outputFile -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Registry policy" -checkID "domain_GPOReRegistry" -status $csvSt -finding "GPO registry policy reprocess is enabled."
 
         }
         else {
             writeToFile -file $outputFile -path $folderLocation -str ' > GPO registry policy reprocess is disabled (this setting was set on purpose). Can be considered a finding.'
-            addToCSV -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Registry policy" -checkID "domain_GPOReRegistry" -problem $true -comment "GPO registry policy reprocess is disabled (this setting was set on purpose)."
+            addToCSV -relatedFile $outputFile -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Registry policy" -checkID "domain_GPOReRegistry" -status $csvOp -finding "GPO registry policy reprocess is disabled (this setting was set on purpose)."
 
         }
     }
@@ -1877,16 +1886,16 @@ function checkGPOReprocess {
     $temp = getRegValue -HKLM $true -regPath "\Software\Policies\Microsoft\Windows\Group Policy\{42B5FAAE-6536-11d2-AE5A-0000F87571E3}" -regName "NoGPOListChanges"
     if ($null -eq $temp) {
         writeToFile -file $outputFile -path $folderLocation -str ' > GPO script policy reprocess is not configured - settings left as default. Can be considered a finding.'
-        addToCSV -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Script policy" -checkID "domain_GPOReScript" -problem $true -comment "GPO script policy reprocess is not configured - settings left as default."
+        addToCSV -relatedFile $outputFile -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Script policy" -checkID "domain_GPOReScript" -status $csvOp -finding "GPO script policy reprocess is not configured - settings left as default."
     }
     else {
         if ($temp.NoGPOListChanges -eq 0) {
             writeToFile -file $outputFile -path $folderLocation -str ' > GPO script policy reprocess is enabled - this is the hardened configuration.'
-            addToCSV -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Script policy" -checkID "domain_GPOReScript" -problem $false -comment "GPO script policy reprocess is enabled."
+            addToCSV -relatedFile $outputFile -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Script policy" -checkID "domain_GPOReScript" -status $csvSt -finding "GPO script policy reprocess is enabled."
         }
         else {
             writeToFile -file $outputFile -path $folderLocation -str ' > GPO script policy reprocess is disabled (this setting was set on purpose). Can be considered a finding.'
-            addToCSV -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Script policy" -checkID "domain_GPOReScript" -problem $true -comment "GPO script policy reprocess is disabled (this setting was set on purpose)."
+            addToCSV -relatedFile $outputFile -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Script policy" -checkID "domain_GPOReScript" -status $csvOp -finding "GPO script policy reprocess is disabled (this setting was set on purpose)."
         }
     }
 
@@ -1894,16 +1903,16 @@ function checkGPOReprocess {
     $temp = getRegValue -HKLM $true -regPath "\Software\Policies\Microsoft\Windows\Group Policy\{827D319E-6EAC-11D2-A4EA-00C04F79F83A}" -regName "NoGPOListChanges"
     if ($null -eq $temp) {
         writeToFile -file $outputFile -path $folderLocation -str ' > GPO security policy reprocess is not configured - settings left as default. Can be considered a finding.'
-        addToCSV -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Security policy" -checkID "domain_GPOReSecurity" -problem $true -comment "GPO security policy reprocess is not configured."
+        addToCSV -relatedFile $outputFile -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Security policy" -checkID "domain_GPOReSecurity" -status $csvOp -finding "GPO security policy reprocess is not configured."
     }
     else {
         if ($temp.NoGPOListChanges -eq 0) {
             writeToFile -file $outputFile -path $folderLocation -str ' > GPO security policy reprocess is enabled - this is the hardened configuration.'
-            addToCSV -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Security policy" -checkID "domain_GPOReSecurity" -problem $false -comment "GPO security policy reprocess is enabled."
+            addToCSV -relatedFile $outputFile -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Security policy" -checkID "domain_GPOReSecurity" -status $csvSt -finding "GPO security policy reprocess is enabled."
         }
         else {
             writeToFile -file $outputFile -path $folderLocation -str ' > GPO security policy reprocess is disabled (this setting was set on purpose). Can be considered a finding.'
-            addToCSV -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Security policy" -checkID "domain_GPOReSecurity" -problem $true -comment "GPO security policy reprocess is disabled (this setting was set on purpose)."
+            addToCSV -relatedFile $outputFile -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Security policy" -checkID "domain_GPOReSecurity" -status $csvOp -finding "GPO security policy reprocess is disabled (this setting was set on purpose)."
         }
     }    
 }
@@ -1922,16 +1931,16 @@ function checkInstallElevated {
     $temp = getRegValue -HKLM $true -regPath "\Software\Policies\Microsoft\Windows\Installer" -regName "AlwaysInstallElevated"
     if($null -eq $temp){
         writeToFile -file $outputFile -path $folderLocation -str ' > No GPO settings exist for "Always install with elevation" - this is good.'
-        addToCSV -category "Machine Hardening - Operation system" -checkName "Always install with elevated privileges" -checkID "machine_installWithElevation" -problem $false -comment "No GPO settings exist for `"Always install with elevation`"."
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Operation system" -checkName "Always install with elevated privileges" -checkID "machine_installWithElevation" -status $csvSt -finding "No GPO settings exist for `"Always install with elevation`"."
     }
     elseif ($temp.AlwaysInstallElevated -eq 1) {
         writeToFile -file $outputFile -path $folderLocation -str ' > Always install with elevated is enabled - this is a finding!'
-        addToCSV -category "Machine Hardening - Operation system" -checkName "Always install with elevated privileges" -checkID "machine_installWithElevation" -problem $true -comment "Always install with elevated is enabled."
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Operation system" -checkName "Always install with elevated privileges" -checkID "machine_installWithElevation" -status $csvOp -finding "Always install with elevated is enabled."
 
     }
     else{
         writeToFile -file $outputFile -path $folderLocation -str ' > GPO for "Always install with elevated" exists but not enforcing installing with elevation - this is good.'
-        addToCSV -category "Machine Hardening - Operation system" -checkName "Always install with elevated privileges" -checkID "machine_installWithElevation" -problem $false -comment "GPO for 'Always install with elevated' exists but not enforcing installing with elevation."
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Operation system" -checkName "Always install with elevated privileges" -checkID "machine_installWithElevation" -status $csvSt -finding "GPO for 'Always install with elevated' exists but not enforcing installing with elevation."
     }    
 }
 
@@ -1949,7 +1958,7 @@ function checkPowerShellAudit {
     writeToFile -file $outputFile -path $folderLocation -str " - Script Block - audits the use of script block in PowerShell commands\scripts."
     writeToFile -file $outputFile -path $folderLocation -str " - Transcript - audits the commands running in PowerShell."
     writeToFile -file $outputFile -path $folderLocation -str " - For more information, see: https://www.mandiant.com/resources/greater-visibilityt"
-    writeToFile -file $outputFile -path $folderLocation -str "For comprehensive audit trail all of those need to be configured and each of them has a special setting that need to be configured to work properly (for example in Module Logging you need to specify whitch modules to audit).`r`n"
+    writeToFile -file $outputFile -path $folderLocation -str "For comprehensive audit trail all of those need to be configured and each of them has a special setting that need to be configured to work properly (for example in Module Logging you need to specify which modules to audit).`r`n"
     # --- Start Of Module Logging ---
     writeToFile -file $outputFile -path $folderLocation -str "--- PowerShell Module audit: "
     $temp = getRegValue -HKLM $true -regPath "\Software\Policies\Microsoft\Windows\PowerShell\ModuleLogging" -regName "EnableModuleLogging"
@@ -1965,18 +1974,18 @@ function checkPowerShellAudit {
             }
             if(!$booltest){
                 writeToFile -file $outputFile -path $folderLocation -str  " > PowerShell - Module Logging is enabled on all modules but only on the user."
-                addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Modules" -checkID "machine_PSModuleLog" -problem $false -comment "Powershell Module Logging is enabled on all modules (Only on current user)."
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Powershell Audit - Modules" -checkID "machine_PSModuleLog" -status $csvSt -finding "Powershell Module Logging is enabled on all modules (Only on current user)."
 
             }
             else{
                 writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Module logging is enabled only on the user and not on all modules."
-                addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Modules" -checkID "machine_PSModuleLog" -problem $true -comment "Powershell Module Logging is not enabled on all modules (Configuration is only on user) - (please check the script output for more information)." 
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Powershell Audit - Modules" -checkID "machine_PSModuleLog" -status $csvOp -finding "Powershell Module Logging is not enabled on all modules (Configuration is only on user) - (please check the script output for more information)." 
                 writeToFile -file $outputFile -path $folderLocation -str ($temp2 | Select-Object -ExpandProperty Property | Out-String) # getting which Module are logged in User-Space  
             } 
         }
         else {
             writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Module Logging is not enabled."
-            addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Modules" -checkID "machine_PSModuleLog" -problem $true -comment "PowerShell Module logging is not enabled!."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Powershell Audit - Modules" -checkID "machine_PSModuleLog" -status $csvOp -finding "PowerShell Module logging is not enabled!."
 
         }
     }
@@ -1990,17 +1999,17 @@ function checkPowerShellAudit {
         }
         if(!$booltest){
             writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Module Logging is not enabled on all modules:" 
-            addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Modules" -checkID "machine_PSModuleLog" -problem $true -comment "Powershell Module Logging is not enabled on all modules (please check the script output for more information)."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Powershell Audit - Modules" -checkID "machine_PSModuleLog" -status $csvOp -finding "Powershell Module Logging is not enabled on all modules (please check the script output for more information)."
             writeToFile -file $outputFile -path $folderLocation -str ($temp2 | Select-Object -ExpandProperty Property | Out-String) # getting which Module are logged in User-Space  
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Module Logging is enabled on all modules."
-            addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Modules" -checkID "machine_PSModuleLog" -problem $fasle -comment "Powershell Module Logging is enabled on all modules."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Powershell Audit - Modules" -checkID "machine_PSModuleLog" -status $csvSt -finding "Powershell Module Logging is enabled on all modules."
         }
     }
     else{
         writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Module logging is not enabled!"
-        addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Modules" -checkID "machine_PSModuleLog" -problem $true -comment "PowerShell Module logging is not enabled!."
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Powershell Audit - Modules" -checkID "machine_PSModuleLog" -status $csvOp -finding "PowerShell Module logging is not enabled!."
     }
 
     # --- End Of Module Logging ---
@@ -2014,28 +2023,28 @@ function checkPowerShellAudit {
             $temp2 = getRegValue -HKLM $false -regPath "\Software\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging" -regName "EnableScriptBlockInvocationLogging"
             if($null -eq $temp2 -or $temp2.EnableScriptBlockInvocationLogging -ne 1){
                 writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Script Block Logging is enabled but Invocation logging is not enabled - only on user." 
-                addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Script Block" -checkID "machine_PSScriptBlock" -problem $false -comment "Script Block Logging is enabled but Invocation logging is not enabled (Only on user)."
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Powershell Audit - Script Block" -checkID "machine_PSScriptBlock" -status $csvSt -finding "Script Block Logging is enabled but Invocation logging is not enabled (Only on user)."
             }
             else{
                 writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Script Block Logging is enabled - only on user."
-                addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Script Block" -checkID "machine_PSScriptBlock" -problem $false -comment "PowerShell Script Block Logging is enabled (Only on current user)."
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Powershell Audit - Script Block" -checkID "machine_PSScriptBlock" -status $csvSt -finding "PowerShell Script Block Logging is enabled (Only on current user)."
 
             }
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Script Block Logging is not enabled!"
-            addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Script Block" -checkID "machine_PSScriptBlock" -problem $true -comment "PowerShell Script Block Logging is disabled."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Powershell Audit - Script Block" -checkID "machine_PSScriptBlock" -status $csvOp -finding "PowerShell Script Block Logging is disabled."
         }
     }
     else{
         $temp2 = getRegValue -HKLM $true -regPath "\Software\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging" -regName "EnableScriptBlockInvocationLogging"
         if($null -eq $temp2 -or $temp2.EnableScriptBlockInvocationLogging -ne 1){
             writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Script Block Logging is enabled but Invocation logging is not."
-            addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Script Block" -checkID "machine_PSScriptBlock" -problem $false -comment "PowerShell Script Block Logging is enabled but Invocation logging is not."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Powershell Audit - Script Block" -checkID "machine_PSScriptBlock" -status $csvSt -finding "PowerShell Script Block Logging is enabled but Invocation logging is not."
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Script Block Logging is enabled."
-            addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Script Block" -checkID "machine_PSScriptBlock" -problem $false -comment "PowerShell Script Block Logging is enabled."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Powershell Audit - Script Block" -checkID "machine_PSScriptBlock" -status $csvSt -finding "PowerShell Script Block Logging is enabled."
 
         }
     }
@@ -2050,24 +2059,24 @@ function checkPowerShellAudit {
             $temp2 = getRegValue -HKLM $false -regPath "\Software\Policies\Microsoft\Windows\PowerShell\Transcription" -regName "EnableInvocationHeader"
             if($null -eq $temp2 -or $temp2.EnableInvocationHeader -ne 1){
                 writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Transcription logging is enabled but Invocation Header logging is not."
-                addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Transcription" -checkID "machine_PSTranscript" -problem $true -comment "PowerShell Transcription logging is enabled but Invocation Header logging is not enforced. (Only on current user)"
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Powershell Audit - Transcription" -checkID "machine_PSTranscript" -status $csvOp -finding "PowerShell Transcription logging is enabled but Invocation Header logging is not enforced. (Only on current user)"
                 $bollCheck = $True
             }
             $temp2 = getRegValue -HKLM $false -regPath "\Software\Policies\Microsoft\Windows\PowerShell\Transcription" -regName "OutputDirectory"
             if($null -eq $temp2 -or $temp2.OutputDirectory -eq ""){
                 writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Transcription logging is enabled but no folder is set to save the log."
-                addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Transcription" -checkID "machine_PSTranscript" -problem $true -comment "PowerShell Transcription logging is enabled but no folder is set to save the log. (Only on current user)"
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Powershell Audit - Transcription" -checkID "machine_PSTranscript" -status $csvOp -finding "PowerShell Transcription logging is enabled but no folder is set to save the log. (Only on current user)"
                 $bollCheck = $True
             }
             if(!$bollCheck){
                 writeToFile -file $outputFile -path $folderLocation -str " > Powershell - Transcription logging is enabled correctly but only on the user."
-                addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Transcription" -checkID "machine_PSTranscript" -problem $false -comment "PowerShell Transcription logging is enabled and configured correctly. (Only on current user)"
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Powershell Audit - Transcription" -checkID "machine_PSTranscript" -status $csvSt -finding "PowerShell Transcription logging is enabled and configured correctly. (Only on current user)"
                 $bollCheck = $True
             }
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Transcription logging is not enabled (logging input and output of PowerShell commands)."
-            addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Transcription" -checkID "machine_PSTranscript" -problem $true -comment "PowerShell Transcription logging is not enabled."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Powershell Audit - Transcription" -checkID "machine_PSTranscript" -status $csvOp -finding "PowerShell Transcription logging is not enabled."
             $bollCheck = $True
         }
     }
@@ -2075,19 +2084,19 @@ function checkPowerShellAudit {
         $temp2 = getRegValue -HKLM $true -regPath "\Software\Policies\Microsoft\Windows\PowerShell\Transcription" -regName "EnableInvocationHeader"
         if($null -eq $temp2 -or $temp2.EnableInvocationHeader -ne 1){
             writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Transcription logging is enabled but Invocation Header logging is not enforced." 
-            addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Transcription" -checkID "machine_PSTranscript" -problem $true -comment "PowerShell Transcription logging is enabled but Invocation Header logging is not enforced."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Powershell Audit - Transcription" -checkID "machine_PSTranscript" -status $csvOp -finding "PowerShell Transcription logging is enabled but Invocation Header logging is not enforced."
             $bollCheck = $True
         }
         $temp2 = getRegValue -HKLM $true -regPath "\Software\Policies\Microsoft\Windows\PowerShell\Transcription" -regName "OutputDirectory"
         if($null -eq $temp2 -or $temp2.OutputDirectory -eq ""){
             writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Transcription logging is enabled but no folder is set to save the log." 
-            addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Transcription" -checkID "machine_PSTranscript" -problem $true -comment "PowerShell Transcription logging is enabled but no folder is set to save the log."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Powershell Audit - Transcription" -checkID "machine_PSTranscript" -status $csvOp -finding "PowerShell Transcription logging is enabled but no folder is set to save the log."
             $bollCheck = $True
         }
     }
     if(!$bollCheck){
         writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Transcription logging is enabled and configured correctly." 
-        addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Transcription" -checkID "machine_PSTranscript" -problem $false -comment "PowerShell Transcription logging is enabled and configured correctly."
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Powershell Audit - Transcription" -checkID "machine_PSTranscript" -status $csvSt -finding "PowerShell Transcription logging is enabled and configured correctly."
     }
     
 }
@@ -2110,11 +2119,11 @@ function checkCommandLineAudit {
     if ((($winVersion.Major -ge 7) -or ($winVersion.Minor -ge 2))){
         if($null -eq $reg){
             writeToFile -file $outputFile -path $folderLocation -str " > Command line process auditing policy is not configured - this can be considered a finding." #using system default depends on OS version
-            addToCSV -category "Machine Hardening - Audit" -checkName "Command line process auditing" -checkID "machine_ComLineLog" -problem $true -comment "Command line process auditing policy is not configured."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Command line process auditing" -checkID "machine_ComLineLog" -status $csvOp -finding "Command line process auditing policy is not configured."
         }
         elseif($reg.ProcessCreationIncludeCmdLine_Enabled -ne 1){
             writeToFile -file $outputFile -path $folderLocation -str " > Command line process auditing policy is not configured correctly - this can be considered a finding." #using system default depends on OS version
-            addToCSV -category "Machine Hardening - Audit" -checkName "Command line process auditing" -checkID "machine_ComLineLog" -problem $true -comment "Command line process auditing policy is not configured correctly."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Command line process auditing" -checkID "machine_ComLineLog" -status $csvOp -finding "Command line process auditing policy is not configured correctly."
         }
         else{
             if($runningAsAdmin)
@@ -2123,23 +2132,23 @@ function checkCommandLineAudit {
                 foreach ($item in $test){
                     if($item -like "*Process Creation*No Auditing"){
                         writeToFile -file $outputFile -path $folderLocation -str " > Command line audit policy is not configured correctly (Advance audit>Detailed Tracking>Process Creation is not configured) - this can be considered a finding." 
-                        addToCSV -category "Machine Hardening - Audit" -checkName "Command line process auditing" -checkID "machine_ComLineLog" -problem $true -comment "Command line audit policy is not configured correctly (Advance audit>Detailed Tracking>Process Creation is not configured)."
+                        addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Command line process auditing" -checkID "machine_ComLineLog" -status $csvOp -finding "Command line audit policy is not configured correctly (Advance audit>Detailed Tracking>Process Creation is not configured)."
                     }
                     elseif ($item -like "*Process Creation*") {
                         writeToFile -file $outputFile -path $folderLocation -str " > Command line audit policy is configured correctly - this is the hardened configuration."
-                        addToCSV -category "Machine Hardening - Audit" -checkName "Command line process auditing" -checkID "machine_ComLineLog" -problem $false -comment "Command line audit policy is configured correctly."
+                        addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Command line process auditing" -checkID "machine_ComLineLog" -status $csvSt -finding "Command line audit policy is configured correctly."
                     }
                 }
             }
             else{
                 writeToLog -str "Function checkCommandLineAudit: unable to run auditpol command to check audit policy - not running as elevated admin."
-                addToCSV -category "Machine Hardening - Audit" -checkName "Command line process auditing" -checkID "machine_ComLineLog" -problem "UNKNOWN" -comment "Unable to run auditpol command to check audit policy (Test did not run in elevation)."
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Command line process auditing" -checkID "machine_ComLineLog" -status $csvUn -finding "Unable to run auditpol command to check audit policy (Test did not run in elevation)."
             }
         }
     }
     else{
         writeToFile -file $outputFile -path $folderLocation -str " > Command line audit policy is not supported in this OS (legacy version) - this is bad..." 
-        addToCSV -category "Machine Hardening - Audit" -checkName "Command line process auditing" -checkID "machine_ComLineLog" -problem $true -comment "Command line audit policy is not supported in this OS (legacy version)."
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Command line process auditing" -checkID "machine_ComLineLog" -status $csvOp -finding "Command line audit policy is not supported in this OS (legacy version)."
     }
 }
 
@@ -2174,17 +2183,17 @@ function checkLogSize {
         writeToFile -file $outputFile -path $folderLocation -str " > Application maximum log file is $size"
         if($applicationLogMaxSize.MaxSize -lt 32768){
             writeToFile -file $outputFile -path $folderLocation -str " > Application maximum log file size is smaller then the recommendation (32768KB) - this is a potential finding, if logs are not collected to a central location."
-            addToCSV -category "Machine Hardening - Audit" -checkName "Application events maximum log file size" -checkID "machine_AppMaxLog" -problem $true -comment "Application maximum log file size is: $size this is smaller then the recommendation (32768KB)."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Application events maximum log file size" -checkID "machine_AppMaxLog" -status $csvOp -finding "Application maximum log file size is: $size this is smaller then the recommendation (32768KB)."
 
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > Application maximum log file size is equal or larger then 32768KB - this is good."
-            addToCSV -category "Machine Hardening - Audit" -checkName "Application events maximum log file size" -checkID "machine_AppMaxLog" -problem $false -comment "Application maximum log file size is: $size this is equal or larger then 32768KB."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Application events maximum log file size" -checkID "machine_AppMaxLog" -status $csvSt -finding "Application maximum log file size is: $size this is equal or larger then 32768KB."
         }
     }
     else{
         writeToFile -file $outputFile -path $folderLocation -str " > Application maximum log file is not configured, the default is 1MB - this is a potential finding, if logs are not collected to a central location."
-        addToCSV -category "Machine Hardening - Audit" -checkName "Application events maximum log file size" -checkID "machine_AppMaxLog" -problem $true -comment "Application maximum log file is not configured, the default is 1MB."
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Application events maximum log file size" -checkID "machine_AppMaxLog" -status $csvOp -finding "Application maximum log file is not configured, the default is 1MB."
     }
 
     writeToFile -file $outputFile -path $folderLocation -str "`r`n--- System ---"
@@ -2202,16 +2211,16 @@ function checkLogSize {
         writeToFile -file $outputFile -path $folderLocation -str " > System maximum log file is $size"
         if($systemLogMaxSize.MaxSize -lt 32768){
             writeToFile -file $outputFile -path $folderLocation -str " > System maximum log file size is smaller then the recommendation (32768KB) - this is a potential finding, if logs are not collected to a central location."
-            addToCSV -category "Machine Hardening - Audit" -checkName "System events maximum log file size" -checkID "machine_SysMaxLog" -problem $true -comment "System maximum log file size is:$size this is smaller then the recommendation (32768KB)."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "System events maximum log file size" -checkID "machine_SysMaxLog" -status $csvOp -finding "System maximum log file size is:$size this is smaller then the recommendation (32768KB)."
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > System maximum log file size is equal or larger then (32768KB) - this is good."
-            addToCSV -category "Machine Hardening - Audit" -checkName "System events maximum log file size" -checkID "machine_SysMaxLog" -problem $false -comment "System maximum log file size is:$size this is equal or larger then (32768KB)."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "System events maximum log file size" -checkID "machine_SysMaxLog" -status $csvSt -finding "System maximum log file size is:$size this is equal or larger then (32768KB)."
         }
     }
     else{
         writeToFile -file $outputFile -path $folderLocation -str " > System maximum log file is not configured, the default is 1MB - this is a potential finding, if logs are not collected to a central location."
-        addToCSV -category "Machine Hardening - Audit" -checkName "System events maximum log file size" -checkID "machine_SysMaxLog" -problem $true -comment "System maximum log file is not configured, the default is 1MB."
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "System events maximum log file size" -checkID "machine_SysMaxLog" -status $csvOp -finding "System maximum log file is not configured, the default is 1MB."
     }
 
     writeToFile -file $outputFile -path $folderLocation -str "`r`n--- Security ---"
@@ -2229,16 +2238,16 @@ function checkLogSize {
         writeToFile -file $outputFile -path $folderLocation -str " > Security maximum log file is $size"
         if($securityLogMaxSize.MaxSize -lt 196608){
             writeToFile -file $outputFile -path $folderLocation -str " > Security maximum log file size is smaller then the recommendation (196608KB) - this is a potential finding, if logs are not collected to a central location."
-            addToCSV -category "Machine Hardening - Audit" -checkName "Security events maximum log file size" -checkID "machine_SecMaxLog" -problem $true -comment "Security maximum log file size is:$size this is smaller then the recommendation (196608KB)."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Security events maximum log file size" -checkID "machine_SecMaxLog" -status $csvOp -finding "Security maximum log file size is:$size this is smaller then the recommendation (196608KB)."
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > Security maximum log file size is equal or larger then 196608KB - this is good."
-            addToCSV -category "Machine Hardening - Audit" -checkName "Security events maximum log file size" -checkID "machine_SecMaxLog" -problem $false -comment "System maximum log file size is:$size this is equal or larger then (196608KB)."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Security events maximum log file size" -checkID "machine_SecMaxLog" -status $csvSt -finding "System maximum log file size is:$size this is equal or larger then (196608KB)."
         }
     }
     else{
         writeToFile -file $outputFile -path $folderLocation -str " > Security maximum log file is not configured, the default is 1MB - this is a potential finding, if logs are not collected to a central location."
-        addToCSV -category "Machine Hardening - Audit" -checkName "Security events maximum log file size" -checkID "machine_SecMaxLog" -problem $true -comment "Security maximum log file is not configured, the default is 1MB."
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Security events maximum log file size" -checkID "machine_SecMaxLog" -status $csvOp -finding "Security maximum log file is not configured, the default is 1MB."
     }
 
     writeToFile -file $outputFile -path $folderLocation -str "`r`n--- Setup ---"
@@ -2256,22 +2265,22 @@ function checkLogSize {
             writeToFile -file $outputFile -path $folderLocation -str " > Setup maximum log file is $size"
             if($setupLogMaxSize.MaxSize -lt 32768){
                 writeToFile -file $outputFile -path $folderLocation -str " > Setup maximum log file size is smaller then the recommendation (32768KB) - this is a potential finding, if logs are not collected to a central location."
-                addToCSV -category "Machine Hardening - Audit" -checkName "Setup events maximum log file size" -checkID "machine_SetupMaxLog" -problem $true -comment "Setup maximum log file size is:$size and smaller then the recommendation (32768KB)."
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Setup events maximum log file size" -checkID "machine_SetupMaxLog" -status $csvOp -finding "Setup maximum log file size is:$size and smaller then the recommendation (32768KB)."
             }
             else{
                 writeToFile -file $outputFile -path $folderLocation -str " > Setup maximum log file size is equal or larger then 32768KB - this is good."
-                addToCSV -category "Machine Hardening - Audit" -checkName "Setup events maximum log file size" -checkID "machine_SetupMaxLog" -problem $false -comment "Setup maximum log file size is:$size and equal or larger then (32768KB)."
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Setup events maximum log file size" -checkID "machine_SetupMaxLog" -status $csvSt -finding "Setup maximum log file size is:$size and equal or larger then (32768KB)."
 
             }
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > Setup log are not enabled."
-            addToCSV -category "Machine Hardening - Audit" -checkName "Setup events maximum log file size" -checkID "machine_SetupMaxLog" -comment "Setup log are not enabled."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Setup events maximum log file size" -checkID "machine_SetupMaxLog" -finding "Setup log are not enabled."
         }
     }
     else{
         writeToFile -file $outputFile -path $folderLocation -str " > Setup maximum log file is not configured or enabled."
-        addToCSV -category "Machine Hardening - Audit" -checkName "Setup events maximum log file size" -checkID "machine_SetupMaxLog" -comment "Setup maximum log file is not configured or enabled."
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Audit" -checkName "Setup events maximum log file size" -checkID "machine_SetupMaxLog" -finding "Setup maximum log file is not configured or enabled."
     }
 
 }
@@ -2289,18 +2298,18 @@ function checkSafeModeAcc4NonAdmin {
     $reg = getRegValue -HKLM $true -regPath "SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" -regName "SafeModeBlockNonAdmins"
     if($null -eq $reg){
         writeToFile -file $outputFile -path $folderLocation -str " > No hardening on Safe mode access by non admins - may be considered a finding if you feel pedant today."
-        addToCSV -category "Machine Hardening - Operation system" -checkName "Safe mode access by non-admins" -checkID "machine_SafeModeAcc4NonAdmin" -problem $true -comment "No hardening on Safe mode access by non admins."
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Operation system" -checkName "Safe mode access by non-admins" -checkID "machine_SafeModeAcc4NonAdmin" -status $csvOp -finding "No hardening on Safe mode access by non admins."
 
     }
     else{
         if($reg.SafeModeBlockNonAdmins -eq 1){
             writeToFile -file $outputFile -path $folderLocation -str " > Block Safe mode access by non-admins is enabled - this is a good thing."
-            addToCSV -category "Machine Hardening - Operation system" -checkName "Safe mode access by non-admins" -checkID "machine_SafeModeAcc4NonAdmin" -problem $false -comment "Block Safe mode access by non-admins is enabled."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Operation system" -checkName "Safe mode access by non-admins" -checkID "machine_SafeModeAcc4NonAdmin" -status $csvSt -finding "Block Safe mode access by non-admins is enabled."
 
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > Block Safe mode access by non-admins is disabled - may be considered a finding if you feel pedant today."
-            addToCSV -category "Machine Hardening - Operation system" -checkName "Safe mode access by non-admins" -checkID "machine_SafeModeAcc4NonAdmin" -problem $true -comment "Block Safe mode access by non-admins is disabled."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Operation system" -checkName "Safe mode access by non-admins" -checkID "machine_SafeModeAcc4NonAdmin" -status $csvOp -finding "Block Safe mode access by non-admins is disabled."
         }
     }
 }
@@ -2316,20 +2325,20 @@ function checkProxyConfiguration {
     $reg = getRegValue -HKLM $true -regPath "Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings" -regName "ProxySettingsPerUser"
     if($null -ne $reg -and $reg.ProxySettingsPerUser -eq 0){
         writeToFile -file $outputFile -path $folderLocation -str " > Proxy is configured on the machine (enforced on all users forced by GPO)"
-        addToCSV -category "Machine Hardening - Networking" -checkName "Proxy configuration location" -checkID "machine_proxyConf" -problem $false -comment "Proxy is configured on the machine (enforced on all users forced by GPO)."
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Networking" -checkName "Proxy configuration location" -checkID "machine_proxyConf" -status $csvSt -finding "Proxy is configured on the machine (enforced on all users forced by GPO)."
     }
     else{
-        addToCSV -category "Machine Hardening - Networking" -checkName "Proxy configuration location" -checkID "machine_proxyConf" -problem $false -comment "Proxy is configured on the user."
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Networking" -checkName "Proxy configuration location" -checkID "machine_proxyConf" -status $csvOp -finding "Proxy is configured on the user."
     }
     if (($winVersion.Major -ge 7) -or ($winVersion.Minor -ge 2)){
         $reg = getRegValue -HKLM $true -regPath "SOFTWARE\Policies\Microsoft\Windows\NetworkIsolation" -regName "DProxiesAuthoritive"
         if($null -ne $reg -and $reg.DProxiesAuthoritive -eq 1){
             writeToFile -file $outputFile -path $folderLocation -str " > Windows Network Isolation's automatic proxy discovery is disabled."
-            addToCSV -category "Machine Hardening - Networking" -checkName "Network Isolation's automatic proxy discovery" -checkID "machine_autoIsoProxyDiscovery" -problem $false -comment "Windows Network Isolation's automatic proxy discovery is disabled."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Networking" -checkName "Network Isolation's automatic proxy discovery" -checkID "machine_autoIsoProxyDiscovery" -status $csvSt -finding "Windows Network Isolation's automatic proxy discovery is disabled."
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > Windows Network Isolation's automatic proxy discovery is enabled! "
-            addToCSV -category "Machine Hardening - Networking" -checkName "Network Isolation's automatic proxy discovery" -checkID "machine_autoIsoProxyDiscovery" -problem $true -comment "Windows Network Isolation's automatic proxy discovery is enabled."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Networking" -checkName "Network Isolation's automatic proxy discovery" -checkID "machine_autoIsoProxyDiscovery" -status $csvOp -finding "Windows Network Isolation's automatic proxy discovery is enabled."
         }
     }
     writeToFile -file $outputFile -path $folderLocation -str "=== Internet Explorer Settings (System-default) ==="
@@ -2337,25 +2346,25 @@ function checkProxyConfiguration {
     $reg2 = getRegValue -HKLM $false -regPath "Software\Policies\Microsoft\Internet Explorer\Control Panel" -regName "Proxy"
     if($null -ne $reg -and $reg.Proxy -eq 1){
         writeToFile -file $outputFile -path $folderLocation -str " > All users cannot change proxy setting - prevention is on the computer level (only in windows other application not always use the system setting)"
-        addToCSV -category "Machine Hardening - Networking" -checkName "Access to configure proxy" -checkID "machine_accConfProxy" -problem $false -comment "All users cannot change proxy setting."
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Networking" -checkName "Access to configure proxy" -checkID "machine_accConfProxy" -status $csvSt -finding "All users cannot change proxy setting."
     }
     elseif($null -ne $reg2 -and $reg2.Proxy -eq 1){
         writeToFile -file $outputFile -path $folderLocation -str " > User cannot change proxy setting - prevention is on the user level (only in windows other application not always use the system setting)"
-        addToCSV -category "Machine Hardening - Networking" -checkName "Access to configure proxy" -checkID "machine_accConfProxy" -problem "UNKNOWN" -comment "User cannot change proxy setting - Other users might have the ability to change this setting."
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Networking" -checkName "Access to configure proxy" -checkID "machine_accConfProxy" -status $csvUn -finding "User cannot change proxy setting - Other users might have the ability to change this setting."
     }
     else {
         writeToFile -file $outputFile -path $folderLocation -str " > User can change proxy setting (only in windows other application not always use the system setting)"
-        addToCSV -category "Machine Hardening - Networking" -checkName "Access to configure proxy" -checkID "machine_accConfProxy" -problem $true -comment "User can change proxy setting."
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Networking" -checkName "Access to configure proxy" -checkID "machine_accConfProxy" -status $csvOp -finding "User can change proxy setting."
     }
 
     $reg = getRegValue -HKLM $true -regPath "Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings" -regName "EnableAutoProxyResultCache"
     if($null -ne $reg -and $reg.EnableAutoProxyResultCache -eq 0){
         writeToFile -file $outputFile -path $folderLocation -str " > Caching of Auto-Proxy scripts is Disable (WPAD Disabled)" # need to check
-        addToCSV -category "Machine Hardening - Networking" -checkName "Caching of Auto-Proxy scripts(WPAD)" -checkID "machine_AutoProxyResultCache" -problem $false -comment "Caching of Auto-Proxy scripts is Disable (WPAD disabled)."
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Networking" -checkName "Caching of Auto-Proxy scripts(WPAD)" -checkID "machine_AutoProxyResultCache" -status $csvSt -finding "Caching of Auto-Proxy scripts is Disable (WPAD disabled)."
     }
     else{
         writeToFile -file $outputFile -path $folderLocation -str " > Caching of Auto-Proxy scripts is enabled (WPAD enabled)" # need to check
-        addToCSV -category "Machine Hardening - Networking" -checkName "Caching of Auto-Proxy scripts(WPAD)" -checkID "machine_AutoProxyResultCache" -problem $false -comment "Caching of Auto-Proxy scripts is enabled (WPAD enabled)."
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Networking" -checkName "Caching of Auto-Proxy scripts(WPAD)" -checkID "machine_AutoProxyResultCache" -status $csvOp -finding "Caching of Auto-Proxy scripts is enabled (WPAD enabled)."
     }
     writeToFile -file $outputFile -path $folderLocation -str "`r`n=== WinHTTP service (Auto Proxy) ==="
     $proxySrv = Get-Service -Name "WinHttpAutoProxySvc" -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
@@ -2368,12 +2377,12 @@ function checkProxyConfiguration {
         }
         if($proxySrv.StartType -eq "Disable"){
             writeToFile -file $outputFile -path $folderLocation -str " > WPAD service start type is disabled - WinHTTP Web Proxy Auto-Discovery Service"
-            addToCSV -category "Machine Hardening - Networking" -checkName "WPAD service" -checkID "machine_WPADSvc" -problem $false -comment "WPAD service start type is disabled (WinHTTP Web Proxy Auto-Discovery)."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Networking" -checkName "WPAD service" -checkID "machine_WPADSvc" -status $csvSt -finding "WPAD service start type is disabled (WinHTTP Web Proxy Auto-Discovery)."
 
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str (" > WPAD service start type is "+$proxySrv.StartType+ " - WinHTTP Web Proxy Auto-Discovery Service")
-            addToCSV -category "Machine Hardening - Networking" -checkName "WPAD service" -checkID "machine_WPADSvc" -problem $true -comment ("WPAD service start type is "+$proxySrv.StartType+ " - WinHTTP Web Proxy Auto-Discovery Service.")
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Networking" -checkName "WPAD service" -checkID "machine_WPADSvc" -status $csvOp -finding ("WPAD service start type is "+$proxySrv.StartType+ " - WinHTTP Web Proxy Auto-Discovery Service.")
         }
         writeToFile -file $outputFile -path $folderLocation -str "`r`n=== Raw data:"
         writeToFile -file $outputFile -path $folderLocation -str ($proxySrv | Format-Table -Property Name, DisplayName,Status,StartType,ServiceType| Out-String)
@@ -2389,11 +2398,11 @@ function checkProxyConfiguration {
     $reg = getRegValue -HKLM $false -regPath "Software\Microsoft\Windows\CurrentVersion\Internet Settings" -regName "ProxyEnable"
     if($null -ne $reg -and $reg.ProxyEnable -eq 1){
         writeToFile -file $outputFile -path $folderLocation -str ($userProxy | Out-String)
-        addToCSV -category "Machine Hardening - Networking" -checkName "Proxy settings" -checkID "machine_proxySet" -problem "UNKNOWN" -comment (($userProxy | Out-String)+".")
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Networking" -checkName "Proxy settings" -checkID "machine_proxySet" -status $csvUn -finding (($userProxy | Out-String)+".")
     }
     else {
         writeToFile -file $outputFile -path $folderLocation -str " > User proxy is disabled"
-        addToCSV -category "Machine Hardening - Networking" -checkName "Proxy settings" -checkID "machine_proxySet" -problem $false -comment "User proxy is disabled."
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Networking" -checkName "Proxy settings" -checkID "machine_proxySet" -status $csvSt -finding "User proxy is disabled."
     }
 
     <# Browser specific tests need to work on it
@@ -2465,22 +2474,22 @@ function checkWinUpdateConfig{
     $reg = getRegValue -HKLM $true -regPath "Software\Policies\Microsoft\Windows\WindowsUpdate\AU" -regName "NoAutoUpdate"
     if($null -ne $reg -and $reg.NoAutoUpdate -eq 0){
         writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is disabled - can be considered a finding."
-        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update" -checkID "machine_autoUpdate" -problem $true -comment "Windows automatic update is disabled."
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Patching" -checkName "Windows automatic update" -checkID "machine_autoUpdate" -status $csvOp -finding "Windows automatic update is disabled."
     }
     else{
-        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update" -checkID "machine_autoUpdate" -problem $false -comment "Windows automatic update is enabled."
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Patching" -checkName "Windows automatic update" -checkID "machine_autoUpdate" -status $csvSt -finding "Windows automatic update is enabled."
         writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is enabled."
     }
     $reg = getRegValue -HKLM $true -regPath "Software\Policies\Microsoft\Windows\WindowsUpdate\AU" -regName "AUOptions"
     switch ($reg.AUOptions) {
         2 { 
             writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is configured to notify for download and notify for install - this may be considered a finding (allows users to not update)." 
-            addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem $true -comment "Windows automatic update is configured to notify for download and notify for install."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -status $csvOp -finding "Windows automatic update is configured to notify for download and notify for install."
             
         }
         3 { 
             writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is configured to auto download and notify for install - this depends if this setting if this is set on servers and there is a manual process to update every month. If so it is OK; otherwise it is not recommended."
-            addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "UNKNOWN" -comment "Windows automatic update is configured to auto download and notify for install (if this setting if this is set on servers and there is a manual process to update every month. If so it is OK)."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -status $csvUn -finding "Windows automatic update is configured to auto download and notify for install (if this setting if this is set on servers and there is a manual process to update every month. If so it is OK)."
          }
         4 { 
             writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is configured to auto download and schedule the install - this is a good thing." 
@@ -2489,40 +2498,40 @@ function checkWinUpdateConfig{
                 switch ($reg.ScheduledInstallDay) {
                     0 { 
                         writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is configured to update every day"
-                        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "false" -comment "Windows automatic update is configured to update every day."
+                        addToCSV -relatedFile $outputFile -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -status "false" -finding "Windows automatic update is configured to update every day."
                      }
                     1 { 
                         writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is configured to update every Sunday"
-                        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "false" -comment "Windows automatic update is configured to update every Sunday."
+                        addToCSV -relatedFile $outputFile -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -status "false" -finding "Windows automatic update is configured to update every Sunday."
                       }
                     2 { 
                         writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is configured to update every Monday" 
-                        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "false" -comment "Windows automatic update is configured to update every Monday."
+                        addToCSV -relatedFile $outputFile -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -status "false" -finding "Windows automatic update is configured to update every Monday."
                  }
                     3 { 
                         writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is configured to update every Tuesday"
-                        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "false" -comment "Windows automatic update is configured to update every Tuesday."
+                        addToCSV -relatedFile $outputFile -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -status "false" -finding "Windows automatic update is configured to update every Tuesday."
                         
                     }
                     4 { 
                         writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is configured to update every Wednesday"
-                        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "false" -comment "Windows automatic update is configured to update every Wednesday."
+                        addToCSV -relatedFile $outputFile -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -status "false" -finding "Windows automatic update is configured to update every Wednesday."
                       }
                     5 { 
                         writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is configured to update every Thursday"
-                        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "false" -comment "Windows automatic update is configured to update every Thursday."
+                        addToCSV -relatedFile $outputFile -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -status "false" -finding "Windows automatic update is configured to update every Thursday."
                       }
                     6 { 
                         writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is configured to update every Friday"
-                        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "false" -comment "Windows automatic update is configured to update every Friday."
+                        addToCSV -relatedFile $outputFile -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -status "false" -finding "Windows automatic update is configured to update every Friday."
                     }
                     7 { 
                         writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is configured to update every Saturday" 
-                        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "false" -comment "Windows automatic update is configured to update every Saturday."
+                        addToCSV -relatedFile $outputFile -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -status "false" -finding "Windows automatic update is configured to update every Saturday."
                      }
                     Default { 
                         writeToFile -file $outputFile -path $folderLocation -str " > Windows Automatic update day is not configured"
-                        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "UNKNOWN" -comment "Windows Automatic update day is not configured"
+                        addToCSV -relatedFile $outputFile -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -status $csvUn -finding "Windows Automatic update day is not configured"
                      }
                 }
             }
@@ -2534,11 +2543,11 @@ function checkWinUpdateConfig{
           }
         5 { 
             writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is configured to allow local admin to choose setting."
-            addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem $true -comment "Windows automatic update is configured to allow local admin to choose setting."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -status $csvOp -finding "Windows automatic update is configured to allow local admin to choose setting."
      }
         Default {
             writeToFile -file $outputFile -path $folderLocation -str " > Unknown Windows update configuration."
-            addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "UNKNOWN" -comment "Unknown Windows update configuration."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -status $csvUn -finding "Unknown Windows update configuration."
     }
     }
     writeToFile -file $outputFile -path $folderLocation -str "`r`n============= WSUS configuration ============="
@@ -2547,7 +2556,7 @@ function checkWinUpdateConfig{
         $reg = getRegValue -HKLM $true -regPath "Software\Policies\Microsoft\Windows\WindowsUpdate" -regName "WUServer"
         if ($null -eq $reg) {
             writeToFile -file $outputFile -path $folderLocation -str " > WSUS configuration found but no server has been configured."
-            addToCSV -category "Machine Hardening - Patching" -checkName "WSUS update" -checkID "machine_wsusUpdate" -problem $true -comment "WSUS configuration found but no server has been configured."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Patching" -checkName "WSUS update" -checkID "machine_wsusUpdate" -status $csvOp -finding "WSUS configuration found but no server has been configured."
         }
         else {
             $test = $reg.WUServer
@@ -2555,7 +2564,7 @@ function checkWinUpdateConfig{
                 writeToFile -file $outputFile -path $folderLocation -str " > WSUS is configured with unencrypted HTTP connection - this configuration may be vulnerable to local privilege escalation and may be considered a finding."
                 writeToFile -file $outputFile -path $folderLocation -str " > For more information, see: https://book.hacktricks.xyz/windows/windows-local-privilege-escalation#wsus"
                 writeToFile -file $outputFile -path $folderLocation -str " > Note that SCCM with Enhanced HTTP configured my be immune to this attack. For more information, see: https://docs.microsoft.com/en-us/mem/configmgr/core/plan-design/hierarchy/enhanced-http"
-                addToCSV -category "Machine Hardening - Patching" -checkName "WSUS update" -checkID "machine_wsusUpdate" -problem $true -comment "WSUS is configured with unencrypted HTTP connection - this configuration may be vulnerable to local privilege escalation."
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Patching" -checkName "WSUS update" -checkID "machine_wsusUpdate" -status $csvOp -finding "WSUS is configured with unencrypted HTTP connection - this configuration may be vulnerable to local privilege escalation."
 
                 $test = $test.Substring(7)
                 if($test.IndexOf("/") -ge 0){
@@ -2564,7 +2573,7 @@ function checkWinUpdateConfig{
             }
             else {
                 writeToFile -file $outputFile -path $folderLocation -str " > WSUS is configured with HTTPS connection - this is the hardened configuration."
-                addToCSV -category "Machine Hardening - Patching" -checkName "WSUS update" -checkID "machine_wsusUpdate" -problem $false -comment "WSUS is configured with HTTPS connection."
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Patching" -checkName "WSUS update" -checkID "machine_wsusUpdate" -status $csvSt -finding "WSUS is configured with HTTPS connection."
                 $test = $test.Substring(8)
                 if($test.IndexOf("/") -ge 0){
                     $test = $test.Substring(0,$test.IndexOf("/"))
@@ -2573,18 +2582,18 @@ function checkWinUpdateConfig{
             try {
                 [IPAddress]$test | Out-Null
                 writeToFile -file $outputFile -path $folderLocation -str " > WSUS is configured with an IP address - this might be a bad practice (using NTLM authentication)."
-                addToCSV -category "Machine Hardening - Patching" -checkName "WSUS update address" -checkID "machine_wsusUpdateAddress" -problem $true -comment "WSUS is configured with an IP address - this might be a bad practice (using NTLM authentication)."
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Patching" -checkName "WSUS update address" -checkID "machine_wsusUpdateAddress" -status $csvOp -finding "WSUS is configured with an IP address - this might be a bad practice (using NTLM authentication)."
             }
             catch {
                 writeToFile -file $outputFile -path $folderLocation -str " > WSUS is configured with a URL address (using kerberos authentication)."
-                addToCSV -category "Machine Hardening - Patching" -checkName "WSUS update address" -checkID "machine_wsusUpdateAddress" -problem $false -comment "WSUS is configured with a URL address (using kerberos authentication)."
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Patching" -checkName "WSUS update address" -checkID "machine_wsusUpdateAddress" -status $csvSt -finding "WSUS is configured with a URL address (using kerberos authentication)."
             }
             writeToFile -file $outputFile -path $folderLocation -str (" > WSUS Server is: "+ $reg.WUServer)
         }
     }
     else{
-        addToCSV -category "Machine Hardening - Patching" -checkName "WSUS update" -checkID "machine_wsusUpdate" -problem "UNKNOWN" -comment "No WSUS configuration found. (Might be managed in anther way)"
-        addToCSV -category "Machine Hardening - Patching" -checkName "WSUS update address" -checkID "machine_wsusUpdateAddress" -comment "No WSUS configuration found. (Might be managed in anther way)"
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Patching" -checkName "WSUS update" -checkID "machine_wsusUpdate" -status $csvUn -finding "No WSUS configuration found. (Might be managed in anther way)"
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Patching" -checkName "WSUS update address" -checkID "machine_wsusUpdateAddress" -status $csvUn -finding "No WSUS configuration found. (Might be managed in anther way)"
         writeToFile -file $outputFile -path $folderLocation -str " > No WSUS configuration found."
     }
 }
@@ -2614,12 +2623,12 @@ function checkUnquotedSePath {
         }
     }
     if ($boolBadPath){
-        addToCSV -category "Vulnerabilities" -checkName "Unquoted path" -checkID "vul_quotedPath" -problem $true -comment ("There are vulnerable services in this machine:"+($badPaths | Out-String)+".")
+        addToCSV -relatedFile $outputFile -category "Vulnerabilities" -checkName "Unquoted path" -checkID "vul_quotedPath" -status $csvOp -finding ("There are vulnerable services in this machine:"+($badPaths | Out-String)+".")
         writeToFile -file $outputFile -path $folderLocation -str " > There are vulnerable services in this machine:"
         writeToFile -file $outputFile -path $folderLocation -str  ($badPaths | Out-String)
     }
     else{
-        addToCSV -category "Vulnerabilities" -checkName "Unquoted path" -checkID "vul_quotedPath" -problem $false -comment "No Service found that is vulnerable with Unquoted path."
+        addToCSV -relatedFile $outputFile -category "Vulnerabilities" -checkName "Unquoted path" -checkID "vul_quotedPath" -status $csvSt -finding "No Service found that is vulnerable with Unquoted path."
         writeToFile -file $outputFile -path $folderLocation -str " > The check did not find any service that is vulnerable to unquoted path escalation attack. This is good."
     }
 }
@@ -2640,29 +2649,29 @@ function checkSimulEhtrAndWifi {
             switch ($reg.fMinimizeConnections) {
                 0 {
                      writeToFile -file $outputFile -path $folderLocation -str " > Machine is not hardened and allow simultaneous connections" 
-                     addToCSV -category "Machine Hardening - Networking" -checkName "Ethernet Simultaneous connections " -checkID "machine_ethSim" -problem $true -comment "Machine allows simultaneous Ethernet connections."
+                     addToCSV -relatedFile $outputFile -category "Machine Hardening - Networking" -checkName "Ethernet Simultaneous connections " -checkID "machine_ethSim" -status $csvOp -finding "Machine allows simultaneous Ethernet connections."
                     }
                 1 { 
                     writeToFile -file $outputFile -path $folderLocation -str " > Any new automatic internet connection is blocked when the computer has at least one active internet connection to a preferred type of network." 
-                    addToCSV -category "Machine Hardening - Networking" -checkName "Ethernet Simultaneous connections " -checkID "machine_ethSim" -problem $false -comment "Machine block's any new automatic internet connection when the computer has at least one active internet connection to a preferred type of network."
+                    addToCSV -relatedFile $outputFile -category "Machine Hardening - Networking" -checkName "Ethernet Simultaneous connections " -checkID "machine_ethSim" -status $csvSt -finding "Machine block's any new automatic internet connection when the computer has at least one active internet connection to a preferred type of network."
                 }
                 2 {
                      writeToFile -file $outputFile -path $folderLocation -str " > Minimize the number of simultaneous connections to the Internet or a Windows Domain is configured to stay connected to cellular." 
-                     addToCSV -category "Machine Hardening - Networking" -checkName "Ethernet Simultaneous connections " -checkID "machine_ethSim" -problem $false -comment "Machine is configured to minimize the number of simultaneous connections to the Internet or a Windows Domain is configured to stay connected to cellular."
+                     addToCSV -relatedFile $outputFile -category "Machine Hardening - Networking" -checkName "Ethernet Simultaneous connections " -checkID "machine_ethSim" -status $csvSt -finding "Machine is configured to minimize the number of simultaneous connections to the Internet or a Windows Domain is configured to stay connected to cellular."
                     }
                 3 { 
                     writeToFile -file $outputFile -path $folderLocation -str " > Machine is hardened and disallow Wi-Fi when connected to Ethernet."
-                    addToCSV -category "Machine Hardening - Networking" -checkName "Ethernet Simultaneous connections " -checkID "machine_ethSim" -problem $false -comment "Machine is configured to disallow Wi-Fi when connected to Ethernet."
+                    addToCSV -relatedFile $outputFile -category "Machine Hardening - Networking" -checkName "Ethernet Simultaneous connections " -checkID "machine_ethSim" -status $csvSt -finding "Machine is configured to disallow Wi-Fi when connected to Ethernet."
                 }
                 Default {
                     writeToFile -file $outputFile -path $folderLocation -str " > Minimize the number of simultaneous connections to the Internet or a Windows Domain is configured with unknown configuration"
-                    addToCSV -category "Machine Hardening - Networking" -checkName "Ethernet Simultaneous connections " -checkID "machine_ethSim" -problem "UNKNOWN" -comment "Machine is configured with unknown configuration."
+                    addToCSV -relatedFile $outputFile -category "Machine Hardening - Networking" -checkName "Ethernet Simultaneous connections " -checkID "machine_ethSim" -status $csvUn -finding "Machine is configured with unknown configuration."
                 }
             }
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > Minimize the number of simultaneous connections to the Internet or a Windows Domain is not configured"
-            addToCSV -category "Machine Hardening - Networking" -checkName "Ethernet Simultaneous connections " -checkID "machine_ethSim" -problem "UNKNOWN" -comment "Machine is missing configuration for simultaneous Ethernet connections (e.g., for servers it is fine to not configure this setting)."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Networking" -checkName "Ethernet Simultaneous connections " -checkID "machine_ethSim" -status $csvUn -finding "Machine is missing configuration for simultaneous Ethernet connections (e.g., for servers it is fine to not configure this setting)."
         }
 
         writeToFile -file $outputFile -path $folderLocation -str "`r`n=== checking if GPO Prohibit connection to non-domain networks when connected to domain authenticated network is configured"
@@ -2671,23 +2680,23 @@ function checkSimulEhtrAndWifi {
         if($null -ne $reg){
             if($reg.fBlockNonDomain -eq 1){
                 writeToFile -file $outputFile -path $folderLocation -str " > Machine is hardened and prohibit connection to non-domain networks when connected to domain authenticated network"
-                addToCSV -category "Machine Hardening - Networking" -checkName "Prohibit connection to non-domain networks" -checkID "machine_PCTNDNetwork" -problem $false -comment "Machine is configured to prohibit connections to non-domain networks when connected to domain authenticated network."
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Networking" -checkName "Prohibit connection to non-domain networks" -checkID "machine_PCTNDNetwork" -status $csvSt -finding "Machine is configured to prohibit connections to non-domain networks when connected to domain authenticated network."
             }
             else{
                 writeToFile -file $outputFile -path $folderLocation -str " > Machine allows connection to non-domain networks when connected to domain authenticated network"
-                addToCSV -category "Machine Hardening - Networking" -checkName "Prohibit connection to non-domain networks" -checkID "machine_PCTNDNetwork" -problem $true -comment "Machine is configured to allow connections to non-domain networks when connected to domain authenticated network."
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Networking" -checkName "Prohibit connection to non-domain networks" -checkID "machine_PCTNDNetwork" -status $csvOp -finding "Machine is configured to allow connections to non-domain networks when connected to domain authenticated network."
             }
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > No configuration found to restrict machine connection to non-domain networks when connected to domain authenticated network"
-            addToCSV -category "Machine Hardening - Networking" -checkName "Prohibit connection to non-domain networks" -checkID "machine_PCTNDNetwork" -problem "UNKNOWN" -comment "No configuration found to restrict machine connection to non-domain networks(e.g., for servers it is fine to not configure this setting)."
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Networking" -checkName "Prohibit connection to non-domain networks" -checkID "machine_PCTNDNetwork" -status $csvUn -finding "No configuration found to restrict machine connection to non-domain networks(e.g., for servers it is fine to not configure this setting)."
         }
       
     }
     else{
         writeToFile -file $outputFile -path $folderLocation -str " > OS is obsolete and those not support network access restriction based on GPO"
-        addToCSV -category "Machine Hardening - Networking" -checkName "Ethernet Simultaneous connections " -checkID "machine_ethSim" -problem "UNKNOWN" -comment "OS is obsolete and those not support network access restriction based on GPO"
-        addToCSV -category "Machine Hardening - Networking" -checkName "Prohibit connection to non-domain networks" -checkID "machine_PCTNDNetwork" -problem "UNKNOWN" -comment "OS is obsolete and those not support network access restriction based on GPO."
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Networking" -checkName "Ethernet Simultaneous connections " -checkID "machine_ethSim" -status $csvUn -finding "OS is obsolete and those not support network access restriction based on GPO"
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Networking" -checkName "Prohibit connection to non-domain networks" -checkID "machine_PCTNDNetwork" -status $csvUn -finding "OS is obsolete and those not support network access restriction based on GPO."
     }
     
 }
@@ -2725,22 +2734,22 @@ function checkMacroAndDDE{
                 $reg = getRegValue -HKLM $false -regPath "Software\Microsoft\Office\$n\Excel\Security" -regName "WorkbookLinkWarnings"
                 if($null -ne $reg){
                     if($reg.WorkbookLinkWarnings -eq 2){
-                        addToCSV -category "Machine Hardening - Software" -checkName "Excel WorkbookLinkWarnings (DDE)" -checkID "machine_excelDDE" -problem $true -comment "Excel WorkbookLinkWarnings (DDE) is disabled."
+                        addToCSV -relatedFile $outputFile -category "Machine Hardening - Software" -checkName "Excel WorkbookLinkWarnings (DDE)" -checkID "machine_excelDDE" -status $csvOp -finding "Excel WorkbookLinkWarnings (DDE) is disabled."
                         writeToFile -file $outputFile -path $folderLocation -str " > Excel WorkbookLinkWarnings (DDE) is disabled."
                     }
                     else{
                         writeToFile -file $outputFile -path $folderLocation -str " > Excel WorkbookLinkWarnings (DDE) is enabled."
-                        addToCSV -category "Machine Hardening - Software" -checkName "Excel WorkbookLinkWarnings (DDE)" -checkID "machine_excelDDE" -problem $false -comment "Excel WorkbookLinkWarnings (DDE) is enabled."
+                        addToCSV -relatedFile $outputFile -category "Machine Hardening - Software" -checkName "Excel WorkbookLinkWarnings (DDE)" -checkID "machine_excelDDE" -status $csvSt -finding "Excel WorkbookLinkWarnings (DDE) is enabled."
                     }
                 }
                 else{
                     writeToFile -file $outputFile -path $folderLocation -str " > Excel no configuration found for DDE in this version."
-                    addToCSV -category "Machine Hardening - Software" -checkName "Excel WorkbookLinkWarnings (DDE)" -checkID "machine_excelDDE" -problem "UNKNOWN" -comment "Excel WorkbookLinkWarnings (DDE) hardening is not configured.(might be managed by other mechanism)."
+                    addToCSV -relatedFile $outputFile -category "Machine Hardening - Software" -checkName "Excel WorkbookLinkWarnings (DDE)" -checkID "machine_excelDDE" -status $csvUn -finding "Excel WorkbookLinkWarnings (DDE) hardening is not configured.(might be managed by other mechanism)."
                 }
             }
             else{
                 writeToFile -file $outputFile -path $folderLocation -str " > Office excel version is older then 2007 no DDE option to disable."
-                addToCSV -category "Machine Hardening - Software" -checkName "Excel WorkbookLinkWarnings (DDE)" -checkID "machine_excelDDE" -problem $true -comment "Office excel version is older then 2007 no DDE option to disable."
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Software" -checkName "Excel WorkbookLinkWarnings (DDE)" -checkID "machine_excelDDE" -status $csvOp -finding "Office excel version is older then 2007 no DDE option to disable."
             }
             if($n -ge 14.0){
                 #Outlook
@@ -2748,16 +2757,16 @@ function checkMacroAndDDE{
                 if($null -ne $reg){
                     if($reg.DontUpdateLinks -eq 1){
                         writeToFile -file $outputFile -path $folderLocation -str " > Outlook update links (DDE) is disabled."
-                        addToCSV -category "Machine Hardening - Software" -checkName "Outlook update links (DDE)" -checkID "machine_outlookDDE" -problem $true -comment "Outlook update links (DDE) is disabled."
+                        addToCSV -relatedFile $outputFile -category "Machine Hardening - Software" -checkName "Outlook update links (DDE)" -checkID "machine_outlookDDE" -status $csvOp -finding "Outlook update links (DDE) is disabled."
                     }
                     else{
                         writeToFile -file $outputFile -path $folderLocation -str " > Outlook update links (DDE) is enabled."
-                        addToCSV -category "Machine Hardening - Software" -checkName "Outlook update links (DDE)" -checkID "machine_outlookDDE" -problem $false -comment "Outlook update links (DDE) is enabled."
+                        addToCSV -relatedFile $outputFile -category "Machine Hardening - Software" -checkName "Outlook update links (DDE)" -checkID "machine_outlookDDE" -status $csvSt -finding "Outlook update links (DDE) is enabled."
                     }
                 }
                 else {
                     writeToFile -file $outputFile -path $folderLocation -str " > Outlook no configuration found for DDE in this version"
-                    addToCSV -category "Machine Hardening - Software" -checkName "Outlook update links (DDE)" -checkID "machine_outlookDDE" -problem "UNKNOWN" -comment "Outlook update links (DDE) hardening is not configured.(might be managed by other mechanism)."
+                    addToCSV -relatedFile $outputFile -category "Machine Hardening - Software" -checkName "Outlook update links (DDE)" -checkID "machine_outlookDDE" -status $csvUn -finding "Outlook update links (DDE) hardening is not configured.(might be managed by other mechanism)."
                 }
 
                 #Word
@@ -2765,16 +2774,16 @@ function checkMacroAndDDE{
                 if($null -ne $reg){
                     if($reg.DontUpdateLinks -eq 1){
                         writeToFile -file $outputFile -path $folderLocation -str " > Word update links (DDE) is disabled."
-                        addToCSV -category "Machine Hardening - Software" -checkName "Word update links (DDE)" -checkID "machine_wordDDE" -problem $true -comment "Word update links (DDE) is disabled."
+                        addToCSV -relatedFile $outputFile -category "Machine Hardening - Software" -checkName "Word update links (DDE)" -checkID "machine_wordDDE" -status $csvOp -finding "Word update links (DDE) is disabled."
                     }
                     else{
                         writeToFile -file $outputFile -path $folderLocation -str " > Word update links (DDE) is enabled."
-                        addToCSV -category "Machine Hardening - Software" -checkName "Word update links (DDE)" -checkID "machine_wordDDE" -problem $false -comment "Word update links (DDE) is enabled."
+                        addToCSV -relatedFile $outputFile -category "Machine Hardening - Software" -checkName "Word update links (DDE)" -checkID "machine_wordDDE" -status $csvSt -finding "Word update links (DDE) is enabled."
                     }
                 }
                 else {
                     writeToFile -file $outputFile -path $folderLocation -str " > Word no configuration found for DDE in this version"
-                    addToCSV -category "Machine Hardening - Software" -checkName "Word update links (DDE)" -checkID "machine_wordDDE" -problem "UNKNOWN" -comment "Word update links (DDE) hardening is not configured.(might be managed by other mechanism)."
+                    addToCSV -relatedFile $outputFile -category "Machine Hardening - Software" -checkName "Word update links (DDE)" -checkID "machine_wordDDE" -status $csvUn -finding "Word update links (DDE) hardening is not configured.(might be managed by other mechanism)."
                 }
 
             }
@@ -2783,24 +2792,24 @@ function checkMacroAndDDE{
                 if($null -ne $reg){
                     if($reg.fNoCalclinksOnopen_90_1 -eq 1){
                         writeToFile -file $outputFile -path $folderLocation -str " > Outlook and Word update links (DDE) is disabled."
-                        addToCSV -category "Machine Hardening - Software" -checkName "Outlook update links (DDE)" -checkID "machine_outlookDDE" -problem $true -comment "Outlook update links (DDE) is disabled."
+                        addToCSV -relatedFile $outputFile -category "Machine Hardening - Software" -checkName "Outlook update links (DDE)" -checkID "machine_outlookDDE" -status $csvOp -finding "Outlook update links (DDE) is disabled."
 
                     }
                     else{
                         writeToFile -file $outputFile -path $folderLocation -str " > Outlook and Word update links (DDE) is enabled."
-                        addToCSV -category "Machine Hardening - Software" -checkName "Outlook update links (DDE)" -checkID "machine_outlookDDE" -problem $false -comment "Outlook update links (DDE) is enabled."
+                        addToCSV -relatedFile $outputFile -category "Machine Hardening - Software" -checkName "Outlook update links (DDE)" -checkID "machine_outlookDDE" -status $csvSt -finding "Outlook update links (DDE) is enabled."
                     }
                 }
                 else {
                     writeToFile -file $outputFile -path $folderLocation -str " > Outlook and Word no configuration found for DDE in this version"
-                    addToCSV -category "Machine Hardening - Software" -checkName "Outlook update links (DDE)" -checkID "machine_outlookDDE" -problem "UNKNOWN" -comment "Outlook update links (DDE) hardening is not configured.(might be managed by other mechanism)"
+                    addToCSV -relatedFile $outputFile -category "Machine Hardening - Software" -checkName "Outlook update links (DDE)" -checkID "machine_outlookDDE" -status $csvUn -finding "Outlook update links (DDE) hardening is not configured.(might be managed by other mechanism)"
                 }
                 
             }
             else{
                 writeToFile -file $outputFile -path $folderLocation -str " > Office outlook version is older then 2007 no DDE option to disable"
-                addToCSV -category "Machine Hardening - Software" -checkName "Outlook update links (DDE)" -checkID "machine_outlookDDE" -problem $true -comment "Office outlook version is older then 2007 no DDE option to disable."
-                addToCSV -category "Machine Hardening - Software" -checkName "Word update links (DDE)" -checkID "machine_wordDDE" -problem $true -comment "Office word version is older then 2007 no DDE option to disable."
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Software" -checkName "Outlook update links (DDE)" -checkID "machine_outlookDDE" -status $csvOp -finding "Office outlook version is older then 2007 no DDE option to disable."
+                addToCSV -relatedFile $outputFile -category "Machine Hardening - Software" -checkName "Word update links (DDE)" -checkID "machine_wordDDE" -status $csvOp -finding "Office word version is older then 2007 no DDE option to disable."
 
             }
 
@@ -2837,48 +2846,48 @@ function checkKerberos{
             switch ($reg.supportedencryptiontypes) {
                 8 { 
                     writeToFile -file $outputFile -path $folderLocation -str " > Kerberos encryption allows AES128 only - this is a good thing" 
-                    addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $false -comment "Kerberos encryption allows AES128 only."
+                    addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -status $csvSt -finding "Kerberos encryption allows AES128 only."
                 }
                 16 { 
                     writeToFile -file $outputFile -path $folderLocation -str " > Kerberos encryption allows AES256 only - this is a good thing"
-                    addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $false -comment "Kerberos encryption allows AES256 only."
+                    addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -status $csvSt -finding "Kerberos encryption allows AES256 only."
                 }
                 24 { 
                     writeToFile -file $outputFile -path $folderLocation -str " > Kerberos encryption allows AES128 + AES256 only - this is a good thing"
-                    addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $false -comment "Kerberos encryption allows AES128 + AES256 only."
+                    addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -status $csvSt -finding "Kerberos encryption allows AES128 + AES256 only."
                 }
                 2147483624 { 
                     writeToFile -file $outputFile -path $folderLocation -str " > Kerberos encryption allows AES128 + Future encryption types  only - this is a good thing"
-                    addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $false -comment "Kerberos encryption allows AES128 + Future encryption types."
+                    addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -status $csvSt -finding "Kerberos encryption allows AES128 + Future encryption types."
                  }
                 2147483632 { 
                     writeToFile -file $outputFile -path $folderLocation -str " > Kerberos encryption allows AES256 + Future encryption types  only - this is a good thing"
-                    addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $false -comment "Kerberos encryption allows AES256 + Future encryption types."
+                    addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -status $csvSt -finding "Kerberos encryption allows AES256 + Future encryption types."
                  }
                 2147483640 { 
                     writeToFile -file $outputFile -path $folderLocation -str " > Kerberos encryption allows AES128 + AES256 + Future encryption types only - this is a good thing"
-                    addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $false -comment "Kerberos encryption allows AES128 + AES256 + Future encryption types."
+                    addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -status $csvSt -finding "Kerberos encryption allows AES128 + AES256 + Future encryption types."
                  }
                 2147483616 { 
                     writeToFile -file $outputFile -path $folderLocation -str " > Kerberos encryption allows Future encryption types only - things will not work properly inside the domain (probably)"
-                    addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $true -comment "Kerberos encryption allows Future encryption types only (e.g., dose not allow any encryption."
+                    addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -status $csvOp -finding "Kerberos encryption allows Future encryption types only (e.g., dose not allow any encryption."
                 }
 
                 0 { 
                     writeToFile -file $outputFile -path $folderLocation -str " > Kerberos encryption allows Default authentication (RC4 and up) - this is a finding"
-                    addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $true -comment "Kerberos encryption allows Default authentication (RC4 and up)."
+                    addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -status $csvOp -finding "Kerberos encryption allows Default authentication (RC4 and up)."
                  }
                 Default {
                     if($reg.supportedencryptiontypes -ge 2147483616){
                         $temp = $reg.supportedencryptiontypes - 2147483616
                         writeToFile -file $outputFile -path $folderLocation -str " > Kerberos encryption allows low encryption the Decimal Value is: $temp and it is including also Future encryption types (subtracted from the number) - this is a finding"
-                        addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $true -comment "Kerberos encryption allows low encryption the Decimal Value is: $temp and it is including also Future encryption types (subtracted from the number)."
+                        addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -status $csvOp -finding "Kerberos encryption allows low encryption the Decimal Value is: $temp and it is including also Future encryption types (subtracted from the number)."
 
                     }
                     else
                     {
                         writeToFile -file $outputFile -path $folderLocation -str " > Kerberos encryption allows low encryption the Decimal Value is:"+ $reg.supportedencryptiontypes +" - this is a finding"
-                        addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $true -comment "Kerberos encryption allows low encryption the Decimal Value is: $temp."
+                        addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -status $csvOp -finding "Kerberos encryption allows low encryption the Decimal Value is: $temp."
                     }
                     writeToFile -file $outputFile -path $folderLocation -str " > For more information: https://techcommunity.microsoft.com/t5/core-infrastructure-and-security/decrypting-the-selection-of-supported-kerberos-encryption-types/ba-p/1628797"
                 }
@@ -2886,7 +2895,7 @@ function checkKerberos{
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > Kerberos encryption allows Default authentication (RC4 and up) - this is a finding"
-            addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $true -comment "Kerberos encryption allows Default authentication (RC4 and up)."
+            addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -status $csvOp -finding "Kerberos encryption allows Default authentication (RC4 and up)."
         }
         <# Additional check might be added in the future 
         $kerbPath =  "HKLM:\SYSTEM\CurrentControlSet\Control\Lsa\Kerberos\Parameters"
@@ -2930,13 +2939,16 @@ function checkKerberos{
     }
     else{
         writeToLog -str "Kerberos security check skipped machine is not part of a domain"
-        addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -comment "Machine is not part of a domain."
+        addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -finding "Machine is not part of a domain."
     }
 }
 
 ### General values
 # get hostname to use as the folder name and file names
 $hostname = hostname
+$csvOp = "Opportunity"
+$csvSt = "Strength"
+$csvUn = "Unknown"
 $partOfDomain = (Get-WmiObject -Class Win32_ComputerSystem).PartOfDomain
 if($partOfDomain){
     $domainName = ((Get-WmiObject -class Win32_ComputerSystem).Domain)
@@ -2984,15 +2996,15 @@ if (!(Test-Path -Path $folderLocation)){
 
 # output log
 writeToLog -str "Computer Name: $hostname"
-addToCSV -category "Information" -checkName "Computer Name" -checkID "info_cName" -problem $null -comment $hostname
-addToCSV -category "Information" -checkName "Script Version" -checkID "info_sVer" -problem $null -comment $Version
+addToCSV -category "Information" -checkName "Computer Name" -checkID "info_cName" -status $null -finding $hostname
+addToCSV -category "Information" -checkName "Script Version" -checkID "info_sVer" -status $null -finding $Version
 writeToLog -str ("Windows Version: " + (Get-WmiObject -class Win32_OperatingSystem).Caption)
-addToCSV -category "Information" -checkName "Windows Version" -checkID "info_wVer" -problem $null -comment ((Get-WmiObject -class Win32_OperatingSystem).Caption)
+addToCSV -category "Information" -checkName "Windows Version" -checkID "info_wVer" -status $null -finding ((Get-WmiObject -class Win32_OperatingSystem).Caption)
 
 writeToLog -str  "Part of Domain: $partOfDomain" 
 if ($partOfDomain)
 {
-    addToCSV -category "Information" -checkName "Domain Name" -checkID "info_dName" -problem $null -comment $domainName
+    addToCSV -category "Information" -checkName "Domain Name" -checkID "info_dName" -status $null -finding $domainName
     writeToLog -str  ("Domain Name: " + $domainName)
     if ((Get-WmiObject -Class Win32_OperatingSystem).ProductType -eq 2)
         {writeToLog -str  "Domain Controller: True" }
@@ -3000,7 +3012,7 @@ if ($partOfDomain)
         {writeToLog -str  "Domain Controller: False"}    
 }
 else{
-    addToCSV -category "Information" -checkName "Domain Name" -checkID "info_dName" -problem $null -comment "WorkGroup"
+    addToCSV -category "Information" -checkName "Domain Name" -checkID "info_dName" -status $null -finding "WorkGroup"
 }
 $user = whoami
 writeToLog -str "Running User: $user"
@@ -3137,7 +3149,7 @@ checkKerberos -name "Domain-Hardening"
 
 #########################################################
 
-$script:checksArray | Select-Object "Category", "CheckName","Problem","Comment","CheckID" | Export-Csv -Path ($folderLocation+"\"+(getNameForFile -name "checks" -extension ".csv")) -NoTypeInformation -ErrorAction SilentlyContinue
+$script:checksArray | Select-Object "Category", "CheckName","Status","Risk","Finding","Comments","Related file","CheckID","BPID" | Export-Csv -Path ($folderLocation+"\"+(getNameForFile -name "checks" -extension ".csv")) -NoTypeInformation -ErrorAction SilentlyContinue
 
 $currTime = Get-Date
 writeToLog -str ("Script End Time (before zipping): " + $currTime.ToString("dd/MM/yyyy HH:mm:ss"))

--- a/WindowsAssessment.ps1
+++ b/WindowsAssessment.ps1
@@ -6,7 +6,7 @@ $Version = "1.30" # used for logging purposes
 <# TODO:
 - Output the results to a single file with a simple table - in progress (only for checks functions)  -
 - Debug antivirus check (got "registry access is not allowed" exception on Windows 10 without admin elevation)
-- Check for bugs in the SMB1 check - fixed need to check
+- Check for bugs in the SMB1 check - fixed need to check.
 - Debug the FirewallProducts check
 - Debug the RDP check on multiple OS versions
 - Add check into NetSessionEnum to see whether running on a DC

--- a/WindowsAssessment.ps1
+++ b/WindowsAssessment.ps1
@@ -194,6 +194,10 @@ function addToCSV {
       }
 }
 
+function addControlsToCSV {
+    #To be added.
+}
+
 #<-------------------------  Data Collection Functions ------------------------->
 # get current user privileges
 function dataWhoAmI {
@@ -759,18 +763,18 @@ function checkCredentialGuard {
         if ($null -eq $DevGuard.SecurityServicesConfigured)
             {
                 writeToFile -file $outputFile -path $folderLocation -str "The WMI query for Device Guard settings has failed. Status unknown."
-                addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-wmi" -problem "UNKNOWN" -comment "WMI query for Device Guard settings has failed" 
+                addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-wmi" -problem "UNKNOWN" -comment "WMI query for Device Guard settings has failed." 
             }
         else {
             if (($DevGuard.SecurityServicesConfigured -contains 1) -and ($DevGuard.SecurityServicesRunning -contains 1))
             {
                 writeToFile -file $outputFile -path $folderLocation -str "Credential Guard is configured and running. Which is good."
-                addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-wmi" -problem $false -comment "Credential Guard is configured and running" 
+                addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-wmi" -problem $false -comment "Credential Guard is configured and running." 
             }
         else
             {
                 writeToFile -file $outputFile -path $folderLocation -str "Credential Guard is turned off. A possible finding."
-                addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-wmi" -problem $true -comment "Credential Guard is turned off" 
+                addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-wmi" -problem $true -comment "Credential Guard is turned off." 
         }    
         }
         writeToFile -file $outputFile -path $folderLocation -str "============= Raw Device Guard Settings from WMI (Including Credential Guard) ============="
@@ -780,19 +784,19 @@ function checkCredentialGuard {
         if ($null -eq $DevGuardPS.DeviceGuardSecurityServicesRunning)
             {
                 writeToFile -file $outputFile -path $folderLocation -str "Credential Guard is turned off. A possible finding."
-                addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-PS" -problem $true -comment "Credential Guard is turned off" 
+                addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-PS" -problem $true -comment "Credential Guard is turned off." 
         }
         else
         {
             if ($null -ne ($DevGuardPS.DeviceGuardSecurityServicesRunning | Where-Object {$_.tostring() -eq "CredentialGuard"}))
                 {
                     writeToFile -file $outputFile -path $folderLocation -str "Credential Guard is configured and running. Which is good."
-                    addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-PS" -problem $false -comment "Credential Guard is configured and running" 
+                    addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-PS" -problem $false -comment "Credential Guard is configured and running." 
                 }
             else
                 {
                     writeToFile -file $outputFile -path $folderLocation -str "Credential Guard is turned off. A possible finding."
-                    addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-PS" -problem $true -comment "Credential Guard is turned off" 
+                    addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-PS" -problem $true -comment "Credential Guard is turned off." 
                 }
         }
         writeToFile -file $outputFile -path $folderLocation -str "============= Raw Device Guard Settings from Get-ComputerInfo ============="
@@ -800,8 +804,8 @@ function checkCredentialGuard {
     }
     else{
         writeToLog -str "Function checkCredentialGuard: not supported OS no check is needed..."
-        addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-PS" -problem $true -comment "OS not supporting Credential Guard" 
-        addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-wmi" -problem $true -comment "OS not supporting Credential Guard" 
+        addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-PS" -problem $true -comment "OS not supporting Credential Guard." 
+        addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - Credential Guard" -checkID "machine_LSA-CG-wmi" -problem $true -comment "OS not supporting Credential Guard." 
     }
     
 }
@@ -820,7 +824,7 @@ function checkLSAProtectionConf {
         if ($null -eq $RunAsPPL)
             {
                 writeToFile -file $outputFile -path $folderLocation -str "RunAsPPL registry value does not exists. LSA protection is off . Which is bad and a possible finding."
-                addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - PPL" -checkID "machine_LSA-ppl" -problem $true -comment "RunAsPPL registry value does not exists. LSA protection is off" 
+                addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - PPL" -checkID "machine_LSA-ppl" -problem $true -comment "RunAsPPL registry value does not exists. LSA protection is off." 
             }
         else
         {
@@ -828,19 +832,19 @@ function checkLSAProtectionConf {
             if ($RunAsPPL.RunAsPPL -eq 1)
                 {
                     writeToFile -file $outputFile -path $folderLocation -str "LSA protection is on. Which is good."
-                    addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - PPL" -checkID "machine_LSA-ppl" -problem $false -comment "LSA protection is on" 
+                    addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - PPL" -checkID "machine_LSA-ppl" -problem $false -comment "LSA protection is on." 
 
                 }
             else
                 {
                     writeToFile -file $outputFile -path $folderLocation -str "LSA protection is off. Which is bad and a possible finding."
-                    addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - PPL" -checkID "machine_LSA-ppl" -problem $true -comment "LSA protection is off (PPL)" 
+                    addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - PPL" -checkID "machine_LSA-ppl" -problem $true -comment "LSA protection is off (PPL)." 
             }
         }
     }
     else{
         writeToLog -str "Function checkLSAProtectionConf: not supported OS no check is needed"
-        addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - PPL" -checkID "machine_LSA-ppl" -problem $true -comment "OS is not supporting LSA protection (PPL)" 
+        addToCSV -category "Machine Hardening - Authentication" -checkName "LSA Protection - PPL" -checkID "machine_LSA-ppl" -problem $true -comment "OS is not supporting LSA protection (PPL)." 
     }
 }
 
@@ -865,24 +869,24 @@ function checkInternetAccess{
             writeToFile -file $outputFile -path $folderLocation -str " > DNS request to 8.8.8.8 DNS server was successful. This may be considered a finding, at least on servers."
             writeToFile -file $outputFile -path $folderLocation -str " > DNS request output: "
             writeToFile -file $outputFile -path $folderLocation -str ($test | Out-String)
-            addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - DNS" -checkID "machine_na-dns" -problem $true -comment "public DNS is accessible" 
+            addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - DNS" -checkID "machine_na-dns" -problem $true -comment "Public DNS is accessible." 
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > DNS request to 8.8.8.8 DNS server received a timeout. This is generally good - direct access to internet DNS isn't allowed."
-            addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - DNS" -checkID "machine_na-dns" -problem $false -comment "public DNS is not accessible" 
+            addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - DNS" -checkID "machine_na-dns" -problem $false -comment "Public DNS is not accessible." 
         }
     }
     else{
         $result = nslookup google.com 8.8.8.8
         if ($result -like "*DNS request timed out*"){
             writeToFile -file $outputFile -path $folderLocation -str " > DNS request to 8.8.8.8 DNS server received a timeout. This is generally good - direct access to internet DNS isn't allowed."
-            addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - DNS" -checkID "machine_na-dns" -problem $false -comment "public DNS is not accessible" 
+            addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - DNS" -checkID "machine_na-dns" -problem $false -comment "Public DNS is not accessible." 
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > DNS request to 8.8.8.8 DNS server didn't receive a timeout. This may be considered a finding, at least on servers."
             writeToFile -file $outputFile -path $folderLocation -str " > DNS request output: "
             writeToFile -file $outputFile -path $folderLocation -str ($result | Out-String)
-            addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - DNS" -checkID "machine_na-dns" -problem $true -comment "public DNS is accessible" 
+            addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - DNS" -checkID "machine_na-dns" -problem $true -comment "Public DNS is accessible." 
         }
     }
     if($psVer -ge 4){
@@ -989,22 +993,22 @@ function checkInternetAccess{
             $naOutput += "; Port 8080: Blocked"
         }
         if($naStdPorts -and $naNStdPorts){
-            addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -problem $true -comment "All ports are open for this machine: $naOutput" 
+            addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -problem $true -comment "All ports are open for this machine: $naOutput." 
         }
         elseif ($naStdPorts){
-            addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -problem "UNKNOWN" -comment "Standard ports (e.g., 80,443) are open for this machine (bad for servers ok for workstations): $naOutput" 
+            addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -problem "UNKNOWN" -comment "Standard ports (e.g., 80,443) are open for this machine (bad for servers ok for workstations): $naOutput." 
         }
         elseif ($naNStdPorts){
-            addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -problem $true -comment "None standard ports are open (maybe miss configuration?) for this machine (bad for servers ok for workstations): $naOutput" 
+            addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -problem $true -comment "None standard ports are open (maybe miss configuration?) for this machine (bad for servers ok for workstations): $naOutput." 
         }
         else{
-            addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -problem $false -comment "All browsing ports seem to be closed: $naOutput" 
+            addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -problem $false -comment "All browsing ports seem to be closed: $naOutput." 
         }
     }
     else{
         writeToFile -file $outputFile -path $folderLocation -str "PowerShell is lower then version 4. Other checks are not supported."
         writeToLog -str "Function checkInternetAccess: PowerShell executing the script does not support curl command. Skipping network connection test."
-        addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -problem "UNKNOWN" -comment "PowerShell executing the script does not support curl command. (e.g., PSv3 and below)" 
+        addToCSV -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -problem "UNKNOWN" -comment "PowerShell executing the script does not support curl command. (e.g., PSv3 and below)." 
     }
     <#
     # very long test - skipping it for now 
@@ -1031,12 +1035,12 @@ function checkSMBHardening {
         if ($SMB1.SMB1 -eq 0)
             {
                 writeToFile -file $outputFile -path $folderLocation -str "SMB1 Server is not supported (based on registry values). Which is nice." 
-                addToCSV -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB1" -checkID "domain_SMBv1" -problem $false -comment "SMB1 Server is not supported" 
+                addToCSV -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB1" -checkID "domain_SMBv1" -problem $false -comment "SMB1 Server is not supported." 
             }
         else
             {
                 writeToFile -file $outputFile -path $folderLocation -str "SMB1 Server is supported (based on registry values). Which is pretty bad and a finding." 
-                addToCSV -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB1" -checkID "domain_SMBv1" -problem $true -comment "SMB1 Server is supported (based on registry values)" 
+                addToCSV -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB1" -checkID "domain_SMBv1" -problem $true -comment "SMB1 Server is supported (based on registry values)." 
             }
         # unknown var will all return false always
         <#
@@ -1049,12 +1053,12 @@ function checkSMBHardening {
         if ($SMB2.SMB2 -eq 0)
             {
                 writeToFile -file $outputFile -path $folderLocation -str "SMB2 and SMB3 Server are not supported (based on registry values). Which is weird, but not a finding." 
-                addToCSV -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB2-3" -checkID "domain_SMBv2-3-reg" -problem $true -comment "SMB2 and SMB3 Server are not supported (based on registry values)" 
+                addToCSV -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB2-3" -checkID "domain_SMBv2-3-reg" -problem $true -comment "SMB2 and SMB3 Server are not supported (based on registry values)." 
             }
         else
             {
                 writeToFile -file $outputFile -path $folderLocation -str "SMB2 and SMB3 Server are supported (based on registry values). Which is OK."
-                addToCSV -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB2-3" -checkID "domain_SMBv2-3-reg" -problem $false -comment "SMB2 and SMB3 Server are supported" 
+                addToCSV -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB2-3" -checkID "domain_SMBv2-3-reg" -problem $false -comment "SMB2 and SMB3 Server are supported." 
              }
         if($psVer -ge 4){
             $smbServerConfig = Get-SmbServerConfiguration
@@ -1062,12 +1066,12 @@ function checkSMBHardening {
             if (!$smbServerConfig.EnableSMB2Protocol)
                 {
                     writeToFile -file $outputFile -path $folderLocation -str "SMB2 Server is not supported (based on Get-SmbServerConfiguration). Which is weird, but not a finding." 
-                    addToCSV -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB2-3" -checkID "domain_SMBv2-3-PS" -problem $true -comment "SMB2 Server is not supported (based on powershell)" 
+                    addToCSV -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB2-3" -checkID "domain_SMBv2-3-PS" -problem $true -comment "SMB2 Server is not supported (based on powershell)." 
                 }
             else
                 {
                     writeToFile -file $outputFile -path $folderLocation -str "SMB2 Server is supported (based on Get-SmbServerConfiguration). Which is OK." 
-                    addToCSV -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB2-3" -checkID "domain_SMBv2-3-PS" -problem $false -comment "SMB2 Server is supported" 
+                    addToCSV -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB2-3" -checkID "domain_SMBv2-3-PS" -problem $false -comment "SMB2 Server is supported." 
                 }
         }
         
@@ -1076,7 +1080,7 @@ function checkSMBHardening {
     {
         writeToFile -file $outputFile -path $folderLocation -str "Old Windows versions (XP or 2003) support only SMB1." 
         writeToLog -str "Function checkSMBHardening: unable to run windows too old"
-        addToCSV -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB2-3" -checkID "domain_SMBv2-3-PS" -problem $true -comment "Old Windows versions (XP or 2003) support only SMB1" 
+        addToCSV -category "Domain Hardening - SMB" -checkName "SMB supported versions - SMB2-3" -checkID "domain_SMBv2-3-PS" -problem $true -comment "Old Windows versions (XP or 2003) support only SMB1." 
     }
     writeToFile -file $outputFile -path $folderLocation -str "============= SMB versions Support (Client Settings) ============="
     # Check if Windows Vista/2008 or above
@@ -1087,30 +1091,30 @@ function checkSMBHardening {
         {
             "0" {
                 writeToFile -file $outputFile -path $folderLocation -str "SMB1 Client is set to 'Boot'. Which is weird. Disabled is better." 
-                addToCSV -category "Domain Hardening - SMB" -checkName "SMB1 - Client" -checkID "domain_SMBv1-client" -problem $true -comment "SMB1 Client is set to 'Boot'" 
+                addToCSV -category "Domain Hardening - SMB" -checkName "SMB1 - Client" -checkID "domain_SMBv1-client" -problem $true -comment "SMB1 Client is set to 'Boot'." 
             }
             "1" {
                 writeToFile -file $outputFile -path $folderLocation -str "SMB1 Client is set to 'System'. Which is not weird. although disabled is better."
-                addToCSV -category "Domain Hardening - SMB" -checkName "SMB1 - Client" -checkID "domain_SMBv1-client" -problem $true -comment "SMB1 Client is set to 'System'" 
+                addToCSV -category "Domain Hardening - SMB" -checkName "SMB1 - Client" -checkID "domain_SMBv1-client" -problem $true -comment "SMB1 Client is set to 'System'." 
             }
             "2" {
                 writeToFile -file $outputFile -path $folderLocation -str "SMB1 Client is set to 'Automatic' (Enabled). Which is not very good, a possible finding, but not a must."
-                addToCSV -category "Domain Hardening - SMB" -checkName "SMB1 - Client" -checkID "domain_SMBv1-client" -problem $true -comment "SMB1 Client is set to 'Automatic' (Enabled)" 
+                addToCSV -category "Domain Hardening - SMB" -checkName "SMB1 - Client" -checkID "domain_SMBv1-client" -problem $true -comment "SMB1 Client is set to 'Automatic' (Enabled)." 
             }
             "3" {
                 writeToFile -file $outputFile -path $folderLocation -str "SMB1 Client is set to 'Manual' (Turned off, but can be started). Which is pretty good, although disabled is better."
-                addToCSV -category "Domain Hardening - SMB" -checkName "SMB1 - Client" -checkID "domain_SMBv1-client" -problem $false -comment "SMB1 Client is set to 'Manual' (Turned off, but can be started)" 
+                addToCSV -category "Domain Hardening - SMB" -checkName "SMB1 - Client" -checkID "domain_SMBv1-client" -problem $false -comment "SMB1 Client is set to 'Manual' (Turned off, but can be started)." 
             }
             "4" {
                 writeToFile -file $outputFile -path $folderLocation -str "SMB1 Client is set to 'Disabled'. Which is nice."
-                addToCSV -category "Domain Hardening - SMB" -checkName "SMB1 - Client" -checkID "domain_SMBv1-client" -problem $false -comment "SMB1 Client is set to 'Disabled'" 
+                addToCSV -category "Domain Hardening - SMB" -checkName "SMB1 - Client" -checkID "domain_SMBv1-client" -problem $false -comment "SMB1 Client is set to 'Disabled'." 
             }
         }
     }
     else
     {
         writeToFile -file $outputFile -path $folderLocation -str "Old Windows versions (XP or 2003) support only SMB1."
-        addToCSV -category "Domain Hardening - SMB" -checkName "SMB1 - Client" -checkID "domain_SMBv1-client" -problem $true -comment "Old Windows versions (XP or 2003) support only SMB1" 
+        addToCSV -category "Domain Hardening - SMB" -checkName "SMB1 - Client" -checkID "domain_SMBv1-client" -problem $true -comment "Old Windows versions (XP or 2003) support only SMB1." 
     }
     writeToFile -file $outputFile -path $folderLocation -str "============= SMB Signing (Server Settings) ============="
     $SmbServerRequireSigning = getRegValue -HKLM $true -regPath "\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters" -regName "RequireSecuritySignature"
@@ -1119,7 +1123,7 @@ function checkSMBHardening {
     {
         writeToFile -file $outputFile -path $folderLocation -str "Microsoft network server: Digitally sign communications (always) = Enabled"
         writeToFile -file $outputFile -path $folderLocation -str "SMB signing is required by the server, Which is good." 
-        addToCSV -category "Domain Hardening - SMB" -checkName "SMB2 - Server signing" -checkID "domain_SMBv1-srvSign" -problem $false -comment "SMB signing is required by the server" 
+        addToCSV -category "Domain Hardening - SMB" -checkName "SMB2 - Server signing" -checkID "domain_SMBv1-srvSign" -problem $false -comment "SMB signing is required by the server." 
 
     }
     else
@@ -1129,14 +1133,14 @@ function checkSMBHardening {
             writeToFile -file $outputFile -path $folderLocation -str "Microsoft network server: Digitally sign communications (always) = Disabled" 
             writeToFile -file $outputFile -path $folderLocation -str "Microsoft network server: Digitally sign communications (if client agrees) = Enabled"
             writeToFile -file $outputFile -path $folderLocation -str "SMB signing is enabled by the server, but not required. Clients of this server are susceptible to man-in-the-middle attacks, if they don't require signing. A possible finding."
-            addToCSV -category "Domain Hardening - SMB" -checkName "SMB2 - Server signing" -checkID "domain_SMBv1-srvSign" -problem $true -comment "SMB signing is enabled by the server, but not required" 
+            addToCSV -category "Domain Hardening - SMB" -checkName "SMB2 - Server signing" -checkID "domain_SMBv1-srvSign" -problem $true -comment "SMB signing is enabled by the server, but not required." 
         }
         else
         {
             writeToFile -file $outputFile -path $folderLocation -str "Microsoft network server: Digitally sign communications (always) = Disabled." 
             writeToFile -file $outputFile -path $folderLocation -str "Microsoft network server: Digitally sign communications (if client agrees) = Disabled." 
             writeToFile -file $outputFile -path $folderLocation -str "SMB signing is disabled by the server. Clients of this server are susceptible to man-in-the-middle attacks. A finding." 
-            addToCSV -category "Domain Hardening - SMB" -checkName "SMB2 - Server signing" -checkID "domain_SMBv1-srvSign" -problem $true -comment "SMB signing is disabled by the server" 
+            addToCSV -category "Domain Hardening - SMB" -checkName "SMB2 - Server signing" -checkID "domain_SMBv1-srvSign" -problem $true -comment "SMB signing is disabled by the server." 
         }
     }
     # potentially, we can also check SMB signing configuration using PowerShell:
@@ -1162,14 +1166,14 @@ function checkSMBHardening {
             writeToFile -file $outputFile -path $folderLocation -str "Microsoft network client: Digitally sign communications (always) = Disabled" 
             writeToFile -file $outputFile -path $folderLocation -str "Microsoft network client: Digitally sign communications (if client agrees) = Enabled"
             writeToFile -file $outputFile -path $folderLocation -str "SMB signing is enabled by the client, but not required. This computer is susceptible to man-in-the-middle attacks against servers that don't require signing. A possible finding."
-            addToCSV -category "Domain Hardening - SMB" -checkName "SMB2 - Client signing" -checkID "domain_SMBv1-clientSign" -problem $true -comment "SMB signing is enabled by the client, but not required" 
+            addToCSV -category "Domain Hardening - SMB" -checkName "SMB2 - Client signing" -checkID "domain_SMBv1-clientSign" -problem $true -comment "SMB signing is enabled by the client, but not required." 
         }
         else
         {
             writeToFile -file $outputFile -path $folderLocation -str "Microsoft network client: Digitally sign communications (always) = Disabled." 
             writeToFile -file $outputFile -path $folderLocation -str "Microsoft network client: Digitally sign communications (if client agrees) = Disabled." 
             writeToFile -file $outputFile -path $folderLocation -str "SMB signing is disabled by the client. This computer is susceptible to man-in-the-middle attacks. A finding."
-            addToCSV -category "Domain Hardening - SMB" -checkName "SMB2 - Client signing" -checkID "domain_SMBv1-clientSign" -problem $true -comment "SMB signing is disabled by the client" 
+            addToCSV -category "Domain Hardening - SMB" -checkName "SMB2 - Client signing" -checkID "domain_SMBv1-clientSign" -problem $true -comment "SMB signing is disabled by the client." 
         }
     }
     if ($psVer -ge 4 -and($null -ne $smbServerConfig) -and ($null -ne $smbClientConfig)) {
@@ -1252,52 +1256,52 @@ function checkRDPSecurity {
         }
     }
     if($rdpGenUsersFlag -and $rdpAdmins){
-        addToCSV -category "Machine Hardening - RDP" -checkName "RDP Allowed Users" -checkID "machine_RDP-Users" -problem $true -comment "RDP Allowed users is highly permissive: $rdpGenUsersFlag additionally local admin are allows to remotely login the rest of the allowed RDP list:$rdpUsers" 
+        addToCSV -category "Machine Hardening - RDP" -checkName "RDP Allowed Users" -checkID "machine_RDP-Users" -problem $true -comment "RDP Allowed users is highly permissive: $rdpGenUsersStr additionally local admin are allows to remotely login the rest of the allowed RDP list (not including default groups like administrators):$rdpUsers." 
     }
     elseif($rdpGenUsersFlag){
-        addToCSV -category "Machine Hardening - RDP" -checkName "RDP Allowed Users" -checkID "machine_RDP-Users" -problem $true -comment "RDP Allowed users is highly permissive: $rdpGenUsersFlag rest of the allowed RDP list:$rdpUsers" 
+        addToCSV -category "Machine Hardening - RDP" -checkName "RDP Allowed Users" -checkID "machine_RDP-Users" -problem $true -comment "RDP Allowed users is highly permissive: $rdpGenUsersStr rest of the allowed RDP list(not including default groups like administrators):$rdpUsers." 
     }
     elseif($rdpAdmins){
-        addToCSV -category "Machine Hardening - RDP" -checkName "RDP Allowed Users" -checkID "machine_RDP-Users" -problem $true -comment "Local admin are allows to remotely login the the allowed RDP users and groups list:$rdpUsers" 
+        addToCSV -category "Machine Hardening - RDP" -checkName "RDP Allowed Users" -checkID "machine_RDP-Users" -problem $true -comment "Local admin are allows to remotely login the the allowed RDP users and groups list(not including default groups like administrators):$rdpUsers." 
     }
     else{
-        addToCSV -category "Machine Hardening - RDP" -checkName "RDP Allowed Users" -checkID "machine_RDP-Users" -problem "UNKNOWN" -comment "Allowed RDP users and groups list:$rdpUsers" 
+        addToCSV -category "Machine Hardening - RDP" -checkName "RDP Allowed Users" -checkID "machine_RDP-Users" -problem "UNKNOWN" -comment "Allowed RDP users and groups list(not including default groups like administrators):$rdpUsers." 
     }
      
     writeToFile -file $outputFile -path $folderLocation -str "============= NLA (Network Level Authentication) ============="
     if ($RDP.UserAuthenticationRequired -eq 1)
         {
             writeToFile -file $outputFile -path $folderLocation -str "NLA is required, which is fine."
-            addToCSV -category "Machine Hardening - RDP" -checkName "RDP - Network Level Authentication" -checkID "machine_RDP-NLA" -problem $false -comment "NLA is required" 
+            addToCSV -category "Machine Hardening - RDP" -checkName "RDP - Network Level Authentication" -checkID "machine_RDP-NLA" -problem $false -comment "NLA is required." 
         }
     if ($RDP.UserAuthenticationRequired -eq 0)
         {
             writeToFile -file $outputFile -path $folderLocation -str "NLA is not required, which is bad. A possible finding."
-            addToCSV -category "Machine Hardening - RDP" -checkName "RDP - Network Level Authentication" -checkID "machine_RDP-NLA" -problem $true -comment "NLA is not required" 
+            addToCSV -category "Machine Hardening - RDP" -checkName "RDP - Network Level Authentication" -checkID "machine_RDP-NLA" -problem $true -comment "NLA is not required." 
 
         }
         writeToFile -file $outputFile -path $folderLocation -str "============= Security Layer (SSL/TLS) ============="
     if ($RDP.SecurityLayer -eq 0)
         {
             writeToFile -file $outputFile -path $folderLocation -str "Native RDP encryption is used instead of SSL/TLS, which is bad. A possible finding."
-            addToCSV -category "Machine Hardening - RDP" -checkName "RDP - Security Layer (SSL/TLS)" -checkID "machine_RDP-TLS" -problem $true -comment "Native RDP encryption is used instead of SSL/TLS" 
+            addToCSV -category "Machine Hardening - RDP" -checkName "RDP - Security Layer (SSL/TLS)" -checkID "machine_RDP-TLS" -problem $true -comment "Native RDP encryption is used instead of SSL/TLS." 
          }
     if ($RDP.SecurityLayer -eq 1)
         {
             writeToFile -file $outputFile -path $folderLocation -str "SSL/TLS is supported, but not required ('Negotiate' setting). Which is not recommended, but not necessary a finding."
-            addToCSV -category "Machine Hardening - RDP" -checkName "RDP - Security Layer (SSL/TLS)" -checkID "machine_RDP-TLS" -problem $true -comment "SSL/TLS is supported, but not required" 
+            addToCSV -category "Machine Hardening - RDP" -checkName "RDP - Security Layer (SSL/TLS)" -checkID "machine_RDP-TLS" -problem $true -comment "SSL/TLS is supported, but not required." 
         }
     if ($RDP.SecurityLayer -eq 2)
         {
             writeToFile -file $outputFile -path $folderLocation -str "SSL/TLS is required for connecting. Which is good."
-            addToCSV -category "Machine Hardening - RDP" -checkName "RDP - Security Layer (SSL/TLS)" -checkID "machine_RDP-TLS" -problem $false -comment "SSL/TLS is required for connecting" 
+            addToCSV -category "Machine Hardening - RDP" -checkName "RDP - Security Layer (SSL/TLS)" -checkID "machine_RDP-TLS" -problem $false -comment "SSL/TLS is required for connecting." 
         }
         writeToFile -file $outputFile -path $folderLocation -str "============= Raw RDP Timeout Settings (from Registry) ============="
     $RDPTimeout = Get-Item "HKLM:\Software\Policies\Microsoft\Windows NT\Terminal Services"
     if ($RDPTimeout.ValueCount -eq 0)
         {
             writeToFile -file $outputFile -path $folderLocation -str "RDP timeout is not configured. A possible finding."
-            addToCSV -category "Machine Hardening - RDP" -checkName "RDP - Timeout" -checkID "machine_RDP-Timeout" -problem $true -comment "RDP timeout is not configured" 
+            addToCSV -category "Machine Hardening - RDP" -checkName "RDP - Timeout" -checkID "machine_RDP-Timeout" -problem $true -comment "RDP timeout is not configured." 
 
     }
     else
@@ -1383,7 +1387,7 @@ function checkAntiVirusStatus {
         if ($null -eq $AntiVirusProducts)
             {
                 writeToFile -file $outputFile -path $folderLocation -str "No Anti Virus products were found."
-                addToCSV -category "Machine Hardening - Security" -checkName "AntiVirus installed system" -checkID "machine_AVName" -problem $true -comment "No AntiVirus detected on machine"  
+                addToCSV -category "Machine Hardening - Security" -checkName "AntiVirus installed system" -checkID "machine_AVName" -problem $true -comment "No AntiVirus detected on machine."  
             }
         writeToFile -file $outputFile -path $folderLocation -str "============= Antivirus Products Status ============="
         $sumOutput = ""
@@ -1415,16 +1419,16 @@ function checkAntiVirusStatus {
         }
         if($sumOutput -ne ""){
             if($outOfDateAV -and $notEnabledAV){
-                addToCSV -category "Machine Hardening - Security" -checkName "AntiVirus installed system" -checkID "machine_AVName" -problem $true -comment "AntiVirus is not enabled and not up to date `n $sumOutput"  
+                addToCSV -category "Machine Hardening - Security" -checkName "AntiVirus installed system" -checkID "machine_AVName" -problem $true -comment "AntiVirus is not enabled and not up to date `n $sumOutput."  
             }
             elseif ($outOfDateAV) {
-                addToCSV -category "Machine Hardening - Security" -checkName "AntiVirus installed system" -checkID "machine_AVName" -problem $true -comment "AntiVirus is not up to date `n $sumOutput"  
+                addToCSV -category "Machine Hardening - Security" -checkName "AntiVirus installed system" -checkID "machine_AVName" -problem $true -comment "AntiVirus is not up to date `n $sumOutput."  
             }
             elseif ($notEnabledAV){
-                addToCSV -category "Machine Hardening - Security" -checkName "AntiVirus installed system" -checkID "machine_AVName" -problem $true -comment "AntiVirus is not enabled `n $sumOutput"  
+                addToCSV -category "Machine Hardening - Security" -checkName "AntiVirus installed system" -checkID "machine_AVName" -problem $true -comment "AntiVirus is not enabled `n $sumOutput."  
             }
             else{
-                addToCSV -category "Machine Hardening - Security" -checkName "AntiVirus installed system" -checkID "machine_AVName" -problem $false -comment "AntiVirus is up to date and enabled `n $sumOutput"  
+                addToCSV -category "Machine Hardening - Security" -checkName "AntiVirus installed system" -checkID "machine_AVName" -problem $false -comment "AntiVirus is up to date and enabled `n $sumOutput."  
             }
         }
         
@@ -1505,13 +1509,13 @@ function checkLLMNRAndNetBIOS {
     if ($LLMNR_Enabled -eq 0)
         {
             writeToFile -file $outputFile -path $folderLocation -str "LLMNR is disabled, which is secure."
-            addToCSV -category "Domain Hardening - Network" -checkName "LLMNR" -checkID "domain_LLMNR" -problem $false -comment "LLMNR is disabled, which is secure"  
+            addToCSV -category "Domain Hardening - Network" -checkName "LLMNR" -checkID "domain_LLMNR" -problem $false -comment "LLMNR is disabled, which is secure."  
 
     }
     else
         {
             writeToFile -file $outputFile -path $folderLocation -str "LLMNR is enabled, which is a finding, especially for workstations."
-            addToCSV -category "Domain Hardening - Network" -checkName "LLMNR" -checkID "domain_LLMNR" -problem $true -comment "LLMNR is enabled"  
+            addToCSV -category "Domain Hardening - Network" -checkName "LLMNR" -checkID "domain_LLMNR" -problem $true -comment "LLMNR is enabled."  
 
         }
         writeToFile -file $outputFile -path $folderLocation -str "============= NETBIOS Name Service Configuration ============="
@@ -1529,19 +1533,19 @@ function checkLLMNRAndNetBIOS {
         {
             $null {
                 writeToFile -file $outputFile -path $folderLocation -str "NetBIOS Node Type is set to the default setting (broadcast queries), which is not secure and a finding."
-                addToCSV -category "Domain Hardening - Network" -checkName "NetBIOS Node type" -checkID "domain_NetBIOSNT" -problem $true -comment "NetBIOS Node Type is set to the default setting (broadcast queries)"  
+                addToCSV -category "Domain Hardening - Network" -checkName "NetBIOS Node type" -checkID "domain_NetBIOSNT" -problem $true -comment "NetBIOS Node Type is set to the default setting (broadcast queries)."  
             }
             1 {
                 writeToFile -file $outputFile -path $folderLocation -str "NetBIOS Node Type is set to B-node (broadcast queries), which is not secure and a finding."
-                addToCSV -category "Domain Hardening - Network" -checkName "NetBIOS Node type" -checkID "domain_NetBIOSNT" -problem $true -comment "NetBIOS Node Type is set to B-node (broadcast queries)"  
+                addToCSV -category "Domain Hardening - Network" -checkName "NetBIOS Node type" -checkID "domain_NetBIOSNT" -problem $true -comment "NetBIOS Node Type is set to B-node (broadcast queries)."  
             }
             4 {
                 writeToFile -file $outputFile -path $folderLocation -str "NetBIOS Node Type is set to M-node (broadcasts first, then queries the WINS name server), which is not secure and a finding."
-                addToCSV -category "Domain Hardening - Network" -checkName "NetBIOS Node type" -checkID "domain_NetBIOSNT" -problem $true -comment "NetBIOS Node Type is set to M-node (broadcasts first, then queries the WINS name server)"  
+                addToCSV -category "Domain Hardening - Network" -checkName "NetBIOS Node type" -checkID "domain_NetBIOSNT" -problem $true -comment "NetBIOS Node Type is set to M-node (broadcasts first, then queries the WINS name server)."  
             }
             8 {
                 writeToFile -file $outputFile -path $folderLocation -str "NetBIOS Node Type is set to H-node (queries the WINS name server first, then broadcasts), which is not secure and a finding."
-                addToCSV -category "Domain Hardening - Network" -checkName "NetBIOS Node type" -checkID "domain_NetBIOSNT" -problem $true -comment "NetBIOS Node Type is set to H-node (queries the WINS name server first, then broadcasts)"  
+                addToCSV -category "Domain Hardening - Network" -checkName "NetBIOS Node type" -checkID "domain_NetBIOSNT" -problem $true -comment "NetBIOS Node Type is set to H-node (queries the WINS name server first, then broadcasts)."  
             }        
         }
 
@@ -1577,7 +1581,7 @@ function checkWDigest {
         if (($winVersion.Major -ge 10) -or (($winVersion.Major -eq 6) -and ($winVersion.Minor -eq 3)))
             {
                 writeToFile -file $outputFile -path $folderLocation -str  "The WDigest protocol is turned off by default for Win8.1/2012R2 and above. So it is OK, but still recommended to set the UseLogonCredential registry value to 0, to revert malicious attempts of enabling WDigest."
-                addToCSV -category "Domain Hardening - Authentication" -checkName "WDigest Clear-Text passwords in lsas" -checkID "domain_WDigest" -problem $false -comment "The WDigest protocol is turned off by default for Win8.1/2012R2 and above."  
+                addToCSV -category "Domain Hardening - Authentication" -checkName "WDigest Clear-Text passwords in LSAS" -checkID "domain_WDigest" -problem $false -comment "The WDigest protocol is turned off by default for Win8.1/2012R2 and above."  
             }
         else
         {
@@ -1585,13 +1589,13 @@ function checkWDigest {
             if (($winVersion.Major -eq 6) -and ($winVersion.Minor -ge 1))    
                 {
                     writeToFile -file $outputFile -path $folderLocation -str "WDigest stores cleartext user credentials in memory by default in Win7/2008/8/2012. A possible finding."
-                    addToCSV -category "Domain Hardening - Authentication" -checkName "WDigest Clear-Text passwords in lsas" -checkID "domain_WDigest" -problem $true -comment "WDigest stores cleartext user credentials in memory by default in Win7/2008/8/2012."  
+                    addToCSV -category "Domain Hardening - Authentication" -checkName "WDigest Clear-Text passwords in LSAS" -checkID "domain_WDigest" -problem $true -comment "WDigest stores cleartext user credentials in memory by default in Win7/2008/8/2012."  
                 }
             else
             {
                 writeToFile -file $outputFile -path $folderLocation -str "The operating system version is not supported. You have worse problems than WDigest configuration."
                 writeToFile -file $outputFile -path $folderLocation -str "WDigest stores cleartext user credentials in memory by default, but this configuration cannot be hardened since it is a legacy OS."
-                addToCSV -category "Domain Hardening - Authentication" -checkName "WDigest Clear-Text passwords in lsas" -checkID "domain_WDigest" -problem $true -comment "WDigest stores cleartext user credentials in memory by default, but this configuration cannot be hardened since it is a legacy OS."  
+                addToCSV -category "Domain Hardening - Authentication" -checkName "WDigest Clear-Text passwords in LSAS" -checkID "domain_WDigest" -problem $true -comment "WDigest stores cleartext user credentials in memory by default, but this configuration cannot be hardened since it is a legacy OS."  
 
             }
         }
@@ -1602,14 +1606,14 @@ function checkWDigest {
         {
             writeToFile -file $outputFile -path $folderLocation -str "WDigest UseLogonCredential registry key set to 0."
             writeToFile -file $outputFile -path $folderLocation -str "WDigest doesn't store cleartext user credentials in memory, which is good. The setting was intentionally hardened."
-            addToCSV -category "Domain Hardening - Authentication" -checkName "WDigest Clear-Text passwords in lsas" -checkID "domain_WDigest" -problem $false -comment "WDigest doesn't store cleartext user credentials in memory"  
+            addToCSV -category "Domain Hardening - Authentication" -checkName "WDigest Clear-Text passwords in LSAS" -checkID "domain_WDigest" -problem $false -comment "WDigest doesn't store cleartext user credentials in memory."  
 
         }
         if ($WDigest.UseLogonCredential -eq 1)
         {
             writeToFile -file $outputFile -path $folderLocation -str "WDigest UseLogonCredential registry key set to 1."
             writeToFile -file $outputFile -path $folderLocation -str "WDigest stores cleartext user credentials in memory, which is bad and a finding. The configuration was either intentionally configured by an admin for some reason, or was set by a threat actor to fetch clear-text credentials."
-            addToCSV -category "Domain Hardening - Authentication" -checkName "WDigest Clear-Text passwords in lsas" -checkID "domain_WDigest" -problem $true -comment "WDigest stores cleartext user credentials in memory"  
+            addToCSV -category "Domain Hardening - Authentication" -checkName "WDigest Clear-Text passwords in LSAS" -checkID "domain_WDigest" -problem $true -comment "WDigest stores cleartext user credentials in memory."  
         }
     }
     
@@ -1676,7 +1680,7 @@ function checkSAMEnum{
         else
             {
                 writeToFile -file $outputFile -path $folderLocation -str "This OS version is not hardened by default and this issue can be seen as a finding."
-                addToCSV -category "Domain Hardening - Enumeration" -checkName "SAM enumeration permissions" -checkID "domain_SAMEnum" -problem $true -comment "Using default settings - this OS version is not hardened by default"
+                addToCSV -category "Domain Hardening - Enumeration" -checkName "SAM enumeration permissions" -checkID "domain_SAMEnum" -problem $true -comment "Using default settings - this OS version is not hardened by default."
             }
     }
     else
@@ -1709,7 +1713,7 @@ function checkPowershellVer {
     {
         $temp = Start-Job {Get-Host} -PSVersion 2.0 -Name "PSv2Check"
         writeToFile -file $outputFile -path $folderLocation -str "PowerShell version 2 is installed and was able to run commands. This is a finding!"
-        addToCSV -category "Machine Hardening - Operation system" -checkName "Powershell version 2 support - 1" -checkID "machine_PSv2.1" -problem $true -comment "PowerShell version 2 is installed and was able to run commands"
+        addToCSV -category "Machine Hardening - Operation system" -checkName "Powershell version 2 support - 1" -checkID "machine_PSv2.1" -problem $true -comment "PowerShell version 2 is installed and was able to run commands."
     }
     catch
     {
@@ -1770,12 +1774,12 @@ function checkPowershellVer {
     if (($LegacyPowerShell.PowerShellVersion -eq "2.0") -or ($LegacyPowerShell.PowerShellVersion -eq "1.0"))
     {
         writeToFile -file $outputFile -path $folderLocation -str ("PowerShell version " + $LegacyPowerShell.PowerShellVersion + " is installed, based on the registry value mentioned above.")
-        addToCSV -category "Machine Hardening - Operation system" -checkName "Powershell version 2 support - 2" -checkID "machine_PSv2.2" -problem $true -comment ("PowerShell version " + $LegacyPowerShell.PowerShellVersion + " is installed, based on the registry value")
+        addToCSV -category "Machine Hardening - Operation system" -checkName "Powershell version 2 support - 2" -checkID "machine_PSv2.2" -problem $true -comment ("PowerShell version " + $LegacyPowerShell.PowerShellVersion + " is installed, based on the registry value.")
     }
     else
     {
         writeToFile -file $outputFile -path $folderLocation -str "PowerShell version 1/2 is not installed." 
-        addToCSV -category "Machine Hardening - Operation system" -checkName "Powershell version 2 support - 2" -checkID "machine_PSv2.2" -problem $false -comment ("PowerShell version 1/2 is not installed")
+        addToCSV -category "Machine Hardening - Operation system" -checkName "Powershell version 2 support - 2" -checkID "machine_PSv2.2" -problem $false -comment ("PowerShell version 1/2 is not installed.")
     }
     
 }
@@ -1795,41 +1799,41 @@ function checkNTLMv2 {
     $temp = getRegValue -HKLM $true -regPath "\SYSTEM\CurrentControlSet\Control\Lsa" -regName "LmCompatibilityLevel"
     if(!($partOfDomain)){
         writeToFile -file $outputFile -path $folderLocation -str " > Machine is not part of a domain." #using system default depends on OS version
-        addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem $false -comment "Machine is not part of a domain"
+        addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem $false -comment "Machine is not part of a domain."
     }
     else{
         if($null -eq $temp){
             writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level Unknown) LM and NTLMv1 restriction does not exist - using OS default. On Windows 2008/7 and above, default is to send NTLMv2 only (Level 3), which is quite secure. `r`n" #using system default depends on OS version
-            addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem $false -comment "NTLM Authentication setting: (Level Unknown) LM and NTLMv1 restriction does not exist - using OS default. On Windows 2008/7 and above, default is to send NTLMv2 only (Level 3)"
+            addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem $false -comment "NTLM Authentication setting: (Level Unknown) LM and NTLMv1 restriction does not exist - using OS default. On Windows 2008/7 and above, default is to send NTLMv2 only (Level 3)."
         }
         switch ($temp.lmcompatibilitylevel) {
             (0) { 
                 writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 0) Send LM and NTLM response; never use NTLM 2 session security. Clients use LM and NTLM authentication, and never use NTLM 2 session security; domain controllers accept LM, NTLM, and NTLM 2 authentication. - this is a finding!`r`n"
-                addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem $true -comment "(Level 0) Send LM and NTLM response; never use NTLM 2 session security. Clients use LM and NTLM authentication, and never use NTLM 2 session security"
+                addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem $true -comment "(Level 0) Send LM and NTLM response; never use NTLM 2 session security. Clients use LM and NTLM authentication, and never use NTLM 2 session security."
             }
             (1) { 
                 writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 1) Use NTLM 2 session security if negotiated. Clients use LM and NTLM authentication, and use NTLM 2 session security if the server supports it; domain controllers accept LM, NTLM, and NTLM 2 authentication. - this is a finding!`r`n"
-                addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem $true -comment "(Level 1) Use NTLM 2 session security if negotiated. Clients use LM and NTLM authentication, and use NTLM 2 session security if the server supports it"
+                addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem $true -comment "(Level 1) Use NTLM 2 session security if negotiated. Clients use LM and NTLM authentication, and use NTLM 2 session security if the server supports it."
             }
             (2) { 
                 writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 2) Send NTLM response only. Clients use only NTLM authentication, and use NTLM 2 session security if the server supports it; domain controllers accept LM, NTLM, and NTLM 2 authentication. - this is a finding!`r`n"
-                addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem $true -comment "(Level 2) Send NTLM response only. Clients use only NTLM authentication, and use NTLM 2 session security if the server supports it"
+                addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem $true -comment "(Level 2) Send NTLM response only. Clients use only NTLM authentication, and use NTLM 2 session security if the server supports it."
             }
             (3) { 
                 writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 3) Send NTLM 2 response only. Clients use NTLM 2 authentication, and use NTLM 2 session security if the server supports it; domain controllers accept LM, NTLM, and NTLM 2 authentication. - Not a finding if all servers are with the same configuration.`r`n"
-                addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem $false -comment "(Level 3) Send NTLM 2 response only. Clients use NTLM 2 authentication, and use NTLM 2 session security if the server supports it"
+                addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem $false -comment "(Level 3) Send NTLM 2 response only. Clients use NTLM 2 authentication, and use NTLM 2 session security if the server supports it."
             }
             (4) { 
                 writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 4) Domain controllers refuse LM responses. Clients use NTLM authentication, and use NTLM 2 session security if the server supports it; domain controllers refuse LM authentication (that is, they accept NTLM and NTLM 2) - Not a finding if all servers are with the same configuration. If this is a DC, it means that LM is not applicable in the domain at all.`r`n"
-                addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem $false -comment "(Level 4) Domain controllers refuse LM responses. Clients use NTLM authentication, and use NTLM 2 session security if the server supports it"
+                addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem $false -comment "(Level 4) Domain controllers refuse LM responses. Clients use NTLM authentication, and use NTLM 2 session security if the server supports it."
             }
             (5) { 
                 writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 5) Domain controllers refuse LM and NTLM responses (accept only NTLM 2). Clients use NTLM 2 authentication, use NTLM 2 session security if the server supports it; domain controllers refuse NTLM and LM authentication (they accept only NTLM 2 - This is the most hardened configuration. If this is a DC, it means that NTLMv2 and LM are not applicable in the domain at all.)`r`n"
-                addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem $false -comment "(Level 5) Domain controllers refuse LM and NTLM responses (accept only NTLM 2). Clients use NTLM 2 authentication, use NTLM 2 session security if the server supports it"
+                addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem $false -comment "(Level 5) Domain controllers refuse LM and NTLM responses (accept only NTLM 2). Clients use NTLM 2 authentication, use NTLM 2 session security if the server supports it."
             }
             Default {
                 writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level Unknown) - " + $temp.lmcompatibilitylevel + "`r`n"
-                addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem "UNKNOWN" -comment ("(Level Unknown) - " + $temp.lmcompatibilitylevel)
+                addToCSV -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -problem "UNKNOWN" -comment ("(Level Unknown) - " + $temp.lmcompatibilitylevel +".")
 
             }
         }
@@ -1859,7 +1863,7 @@ function checkGPOReprocess {
     else {
         if ($temp.NoGPOListChanges -eq 0) {
             writeToFile -file $outputFile -path $folderLocation -str ' > GPO registry policy reprocess is enabled - this is the hardened configuration.'
-            addToCSV -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Registry policy" -checkID "domain_GPOReRegistry" -problem $false -comment "GPO registry policy reprocess is enabled"
+            addToCSV -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Registry policy" -checkID "domain_GPOReRegistry" -problem $false -comment "GPO registry policy reprocess is enabled."
 
         }
         else {
@@ -1878,11 +1882,11 @@ function checkGPOReprocess {
     else {
         if ($temp.NoGPOListChanges -eq 0) {
             writeToFile -file $outputFile -path $folderLocation -str ' > GPO script policy reprocess is enabled - this is the hardened configuration.'
-            addToCSV -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Script policy" -checkID "domain_GPOReScript" -problem $false -comment "GPO script policy reprocess is enabled"
+            addToCSV -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Script policy" -checkID "domain_GPOReScript" -problem $false -comment "GPO script policy reprocess is enabled."
         }
         else {
             writeToFile -file $outputFile -path $folderLocation -str ' > GPO script policy reprocess is disabled (this setting was set on purpose). Can be considered a finding.'
-            addToCSV -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Script policy" -checkID "domain_GPOReScript" -problem $true -comment "GPO script policy reprocess is disabled (this setting was set on purpose)"
+            addToCSV -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Script policy" -checkID "domain_GPOReScript" -problem $true -comment "GPO script policy reprocess is disabled (this setting was set on purpose)."
         }
     }
 
@@ -1890,12 +1894,12 @@ function checkGPOReprocess {
     $temp = getRegValue -HKLM $true -regPath "\Software\Policies\Microsoft\Windows\Group Policy\{827D319E-6EAC-11D2-A4EA-00C04F79F83A}" -regName "NoGPOListChanges"
     if ($null -eq $temp) {
         writeToFile -file $outputFile -path $folderLocation -str ' > GPO security policy reprocess is not configured - settings left as default. Can be considered a finding.'
-        addToCSV -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Security policy" -checkID "domain_GPOReSecurity" -problem $true -comment "GPO security policy reprocess is not configured"
+        addToCSV -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Security policy" -checkID "domain_GPOReSecurity" -problem $true -comment "GPO security policy reprocess is not configured."
     }
     else {
         if ($temp.NoGPOListChanges -eq 0) {
             writeToFile -file $outputFile -path $folderLocation -str ' > GPO security policy reprocess is enabled - this is the hardened configuration.'
-            addToCSV -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Security policy" -checkID "domain_GPOReSecurity" -problem $false -comment "GPO security policy reprocess is enabled"
+            addToCSV -category "Domain Hardening - General" -checkName "GPO reprocess enforcement - Security policy" -checkID "domain_GPOReSecurity" -problem $false -comment "GPO security policy reprocess is enabled."
         }
         else {
             writeToFile -file $outputFile -path $folderLocation -str ' > GPO security policy reprocess is disabled (this setting was set on purpose). Can be considered a finding.'
@@ -1918,16 +1922,16 @@ function checkInstallElevated {
     $temp = getRegValue -HKLM $true -regPath "\Software\Policies\Microsoft\Windows\Installer" -regName "AlwaysInstallElevated"
     if($null -eq $temp){
         writeToFile -file $outputFile -path $folderLocation -str ' > No GPO settings exist for "Always install with elevation" - this is good.'
-        addToCSV -category "Machine Hardening - Operation system" -checkName "Always install with elevated privileges" -checkID "machine_installWithElevation" -problem $false -comment "No GPO settings exist for `"Always install with elevation`""
+        addToCSV -category "Machine Hardening - Operation system" -checkName "Always install with elevated privileges" -checkID "machine_installWithElevation" -problem $false -comment "No GPO settings exist for `"Always install with elevation`"."
     }
     elseif ($temp.AlwaysInstallElevated -eq 1) {
         writeToFile -file $outputFile -path $folderLocation -str ' > Always install with elevated is enabled - this is a finding!'
-        addToCSV -category "Machine Hardening - Operation system" -checkName "Always install with elevated privileges" -checkID "machine_installWithElevation" -problem $true -comment "Always install with elevated is enabled"
+        addToCSV -category "Machine Hardening - Operation system" -checkName "Always install with elevated privileges" -checkID "machine_installWithElevation" -problem $true -comment "Always install with elevated is enabled."
 
     }
     else{
         writeToFile -file $outputFile -path $folderLocation -str ' > GPO for "Always install with elevated" exists but not enforcing installing with elevation - this is good.'
-        addToCSV -category "Machine Hardening - Operation system" -checkName "Always install with elevated privileges" -checkID "machine_installWithElevation" -problem $false -comment "GPO for 'Always install with elevated' exists but not enforcing installing with elevation"
+        addToCSV -category "Machine Hardening - Operation system" -checkName "Always install with elevated privileges" -checkID "machine_installWithElevation" -problem $false -comment "GPO for 'Always install with elevated' exists but not enforcing installing with elevation."
     }    
 }
 
@@ -1961,18 +1965,18 @@ function checkPowerShellAudit {
             }
             if(!$booltest){
                 writeToFile -file $outputFile -path $folderLocation -str  " > PowerShell - Module Logging is enabled on all modules but only on the user."
-                addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Modules" -checkID "machine_PSModuleLog" -problem $false -comment "Powershell Module Logging is enabled on all modules. (Only on current user)"
+                addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Modules" -checkID "machine_PSModuleLog" -problem $false -comment "Powershell Module Logging is enabled on all modules (Only on current user)."
 
             }
             else{
                 writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Module logging is enabled only on the user and not on all modules."
-                addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Modules" -checkID "machine_PSModuleLog" -problem $true -comment "Powershell Module Logging is not enabled on all modules (Configuration is only on user) - (please check the script output for more information)" 
+                addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Modules" -checkID "machine_PSModuleLog" -problem $true -comment "Powershell Module Logging is not enabled on all modules (Configuration is only on user) - (please check the script output for more information)." 
                 writeToFile -file $outputFile -path $folderLocation -str ($temp2 | Select-Object -ExpandProperty Property | Out-String) # getting which Module are logged in User-Space  
             } 
         }
         else {
             writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Module Logging is not enabled."
-            addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Modules" -checkID "machine_PSModuleLog" -problem $true -comment "PowerShell Module logging is not enabled!"
+            addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Modules" -checkID "machine_PSModuleLog" -problem $true -comment "PowerShell Module logging is not enabled!."
 
         }
     }
@@ -1986,7 +1990,7 @@ function checkPowerShellAudit {
         }
         if(!$booltest){
             writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Module Logging is not enabled on all modules:" 
-            addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Modules" -checkID "machine_PSModuleLog" -problem $true -comment "Powershell Module Logging is not enabled on all modules (please check the script output for more information)"
+            addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Modules" -checkID "machine_PSModuleLog" -problem $true -comment "Powershell Module Logging is not enabled on all modules (please check the script output for more information)."
             writeToFile -file $outputFile -path $folderLocation -str ($temp2 | Select-Object -ExpandProperty Property | Out-String) # getting which Module are logged in User-Space  
         }
         else{
@@ -1996,7 +2000,7 @@ function checkPowerShellAudit {
     }
     else{
         writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Module logging is not enabled!"
-        addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Modules" -checkID "machine_PSModuleLog" -problem $true -comment "PowerShell Module logging is not enabled!"
+        addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Modules" -checkID "machine_PSModuleLog" -problem $true -comment "PowerShell Module logging is not enabled!."
     }
 
     # --- End Of Module Logging ---
@@ -2010,17 +2014,17 @@ function checkPowerShellAudit {
             $temp2 = getRegValue -HKLM $false -regPath "\Software\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging" -regName "EnableScriptBlockInvocationLogging"
             if($null -eq $temp2 -or $temp2.EnableScriptBlockInvocationLogging -ne 1){
                 writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Script Block Logging is enabled but Invocation logging is not enabled - only on user." 
-                addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Script Block" -checkID "machine_PSScriptBlock" -problem $false -comment "Script Block Logging is enabled but Invocation logging is not enabled (Only on user)"
+                addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Script Block" -checkID "machine_PSScriptBlock" -problem $false -comment "Script Block Logging is enabled but Invocation logging is not enabled (Only on user)."
             }
             else{
                 writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Script Block Logging is enabled - only on user."
-                addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Script Block" -checkID "machine_PSScriptBlock" -problem $false -comment "PowerShell Script Block Logging is enabled (Only on current user)"
+                addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Script Block" -checkID "machine_PSScriptBlock" -problem $false -comment "PowerShell Script Block Logging is enabled (Only on current user)."
 
             }
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Script Block Logging is not enabled!"
-            addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Script Block" -checkID "machine_PSScriptBlock" -problem $true -comment "PowerShell Script Block Logging is disabled"
+            addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Script Block" -checkID "machine_PSScriptBlock" -problem $true -comment "PowerShell Script Block Logging is disabled."
         }
     }
     else{
@@ -2063,7 +2067,7 @@ function checkPowerShellAudit {
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > PowerShell - Transcription logging is not enabled (logging input and output of PowerShell commands)."
-            addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Transcription" -checkID "machine_PSTranscript" -problem $true -comment "PowerShell Transcription logging is not enabled"
+            addToCSV -category "Machine Hardening - Audit" -checkName "Powershell Audit - Transcription" -checkID "machine_PSTranscript" -problem $true -comment "PowerShell Transcription logging is not enabled."
             $bollCheck = $True
         }
     }
@@ -2106,11 +2110,11 @@ function checkCommandLineAudit {
     if ((($winVersion.Major -ge 7) -or ($winVersion.Minor -ge 2))){
         if($null -eq $reg){
             writeToFile -file $outputFile -path $folderLocation -str " > Command line process auditing policy is not configured - this can be considered a finding." #using system default depends on OS version
-            addToCSV -category "Machine Hardening - Audit" -checkName "Command line process auditing" -checkID "machine_ComLineLog" -problem $true -comment "Command line process auditing policy is not configured"
+            addToCSV -category "Machine Hardening - Audit" -checkName "Command line process auditing" -checkID "machine_ComLineLog" -problem $true -comment "Command line process auditing policy is not configured."
         }
         elseif($reg.ProcessCreationIncludeCmdLine_Enabled -ne 1){
             writeToFile -file $outputFile -path $folderLocation -str " > Command line process auditing policy is not configured correctly - this can be considered a finding." #using system default depends on OS version
-            addToCSV -category "Machine Hardening - Audit" -checkName "Command line process auditing" -checkID "machine_ComLineLog" -problem $true -comment "Command line process auditing policy is not configured correctly"
+            addToCSV -category "Machine Hardening - Audit" -checkName "Command line process auditing" -checkID "machine_ComLineLog" -problem $true -comment "Command line process auditing policy is not configured correctly."
         }
         else{
             if($runningAsAdmin)
@@ -2119,23 +2123,23 @@ function checkCommandLineAudit {
                 foreach ($item in $test){
                     if($item -like "*Process Creation*No Auditing"){
                         writeToFile -file $outputFile -path $folderLocation -str " > Command line audit policy is not configured correctly (Advance audit>Detailed Tracking>Process Creation is not configured) - this can be considered a finding." 
-                        addToCSV -category "Machine Hardening - Audit" -checkName "Command line process auditing" -checkID "machine_ComLineLog" -problem $true -comment "Command line audit policy is not configured correctly (Advance audit>Detailed Tracking>Process Creation is not configured)"
+                        addToCSV -category "Machine Hardening - Audit" -checkName "Command line process auditing" -checkID "machine_ComLineLog" -problem $true -comment "Command line audit policy is not configured correctly (Advance audit>Detailed Tracking>Process Creation is not configured)."
                     }
                     elseif ($item -like "*Process Creation*") {
                         writeToFile -file $outputFile -path $folderLocation -str " > Command line audit policy is configured correctly - this is the hardened configuration."
-                        addToCSV -category "Machine Hardening - Audit" -checkName "Command line process auditing" -checkID "machine_ComLineLog" -problem $false -comment "Command line audit policy is configured correctly"
+                        addToCSV -category "Machine Hardening - Audit" -checkName "Command line process auditing" -checkID "machine_ComLineLog" -problem $false -comment "Command line audit policy is configured correctly."
                     }
                 }
             }
             else{
                 writeToLog -str "Function checkCommandLineAudit: unable to run auditpol command to check audit policy - not running as elevated admin."
-                addToCSV -category "Machine Hardening - Audit" -checkName "Command line process auditing" -checkID "machine_ComLineLog" -problem "UNKNOWN" -comment "Unable to run auditpol command to check audit policy (Test did not run in elevation)"
+                addToCSV -category "Machine Hardening - Audit" -checkName "Command line process auditing" -checkID "machine_ComLineLog" -problem "UNKNOWN" -comment "Unable to run auditpol command to check audit policy (Test did not run in elevation)."
             }
         }
     }
     else{
         writeToFile -file $outputFile -path $folderLocation -str " > Command line audit policy is not supported in this OS (legacy version) - this is bad..." 
-        addToCSV -category "Machine Hardening - Audit" -checkName "Command line process auditing" -checkID "machine_ComLineLog" -problem $true -comment "Command line audit policy is not supported in this OS (legacy version)"
+        addToCSV -category "Machine Hardening - Audit" -checkName "Command line process auditing" -checkID "machine_ComLineLog" -problem $true -comment "Command line audit policy is not supported in this OS (legacy version)."
     }
 }
 
@@ -2159,8 +2163,10 @@ function checkLogSize {
         
         $size = "MB"
         $Calc = [double]::Parse($applicationLogMaxSize.MaxSize) / 1024
+        $Calc = [Math]::Ceiling($Calc)
         if($Calc -ge 1024){
             $Calc = $Calc / 1024
+            $Calc = [Math]::Ceiling($Calc)
             $size = "GB"
         }
 
@@ -2168,17 +2174,17 @@ function checkLogSize {
         writeToFile -file $outputFile -path $folderLocation -str " > Application maximum log file is $size"
         if($applicationLogMaxSize.MaxSize -lt 32768){
             writeToFile -file $outputFile -path $folderLocation -str " > Application maximum log file size is smaller then the recommendation (32768KB) - this is a potential finding, if logs are not collected to a central location."
-            addToCSV -category "Machine Hardening - Audit" -checkName "Application events maximum log file size" -checkID "machine_AppMaxLog" -problem $true -comment "Application maximum log file size is: $size this is smaller then the recommendation (32768KB)"
+            addToCSV -category "Machine Hardening - Audit" -checkName "Application events maximum log file size" -checkID "machine_AppMaxLog" -problem $true -comment "Application maximum log file size is: $size this is smaller then the recommendation (32768KB)."
 
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > Application maximum log file size is equal or larger then 32768KB - this is good."
-            addToCSV -category "Machine Hardening - Audit" -checkName "Application events maximum log file size" -checkID "machine_AppMaxLog" -problem $false -comment "Application maximum log file size is: $size this is equal or larger then 32768KB"
+            addToCSV -category "Machine Hardening - Audit" -checkName "Application events maximum log file size" -checkID "machine_AppMaxLog" -problem $false -comment "Application maximum log file size is: $size this is equal or larger then 32768KB."
         }
     }
     else{
         writeToFile -file $outputFile -path $folderLocation -str " > Application maximum log file is not configured, the default is 1MB - this is a potential finding, if logs are not collected to a central location."
-        addToCSV -category "Machine Hardening - Audit" -checkName "Application events maximum log file size" -checkID "machine_AppMaxLog" -problem $true -comment "Application maximum log file is not configured, the default is 1MB"
+        addToCSV -category "Machine Hardening - Audit" -checkName "Application events maximum log file size" -checkID "machine_AppMaxLog" -problem $true -comment "Application maximum log file is not configured, the default is 1MB."
     }
 
     writeToFile -file $outputFile -path $folderLocation -str "`r`n--- System ---"
@@ -2186,24 +2192,26 @@ function checkLogSize {
         
         $size = "MB"
         $Calc = [double]::Parse($systemLogMaxSize.MaxSize) / 1024
+        $Calc = [Math]::Ceiling($Calc)
         if($Calc -ge 1024){
             $Calc = $Calc / 1024
+            $Calc = [Math]::Ceiling($Calc)
             $size = "GB"
         }
         $size = $Calc.tostring() + $size
         writeToFile -file $outputFile -path $folderLocation -str " > System maximum log file is $size"
         if($systemLogMaxSize.MaxSize -lt 32768){
             writeToFile -file $outputFile -path $folderLocation -str " > System maximum log file size is smaller then the recommendation (32768KB) - this is a potential finding, if logs are not collected to a central location."
-            addToCSV -category "Machine Hardening - Audit" -checkName "System events maximum log file size" -checkID "machine_SysMaxLog" -problem $true -comment "System maximum log file size is:$size this is smaller then the recommendation (32768KB)"
+            addToCSV -category "Machine Hardening - Audit" -checkName "System events maximum log file size" -checkID "machine_SysMaxLog" -problem $true -comment "System maximum log file size is:$size this is smaller then the recommendation (32768KB)."
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > System maximum log file size is equal or larger then (32768KB) - this is good."
-            addToCSV -category "Machine Hardening - Audit" -checkName "System events maximum log file size" -checkID "machine_SysMaxLog" -problem $false -comment "System maximum log file size is:$size this is equal or larger then (32768KB)"
+            addToCSV -category "Machine Hardening - Audit" -checkName "System events maximum log file size" -checkID "machine_SysMaxLog" -problem $false -comment "System maximum log file size is:$size this is equal or larger then (32768KB)."
         }
     }
     else{
         writeToFile -file $outputFile -path $folderLocation -str " > System maximum log file is not configured, the default is 1MB - this is a potential finding, if logs are not collected to a central location."
-        addToCSV -category "Machine Hardening - Audit" -checkName "System events maximum log file size" -checkID "machine_SysMaxLog" -problem $true -comment "System maximum log file is not configured, the default is 1MB"
+        addToCSV -category "Machine Hardening - Audit" -checkName "System events maximum log file size" -checkID "machine_SysMaxLog" -problem $true -comment "System maximum log file is not configured, the default is 1MB."
     }
 
     writeToFile -file $outputFile -path $folderLocation -str "`r`n--- Security ---"
@@ -2211,24 +2219,26 @@ function checkLogSize {
         
         $size = "MB"
         $Calc = [double]::Parse($securityLogMaxSize.MaxSize) / 1024
+        $Calc = [Math]::Ceiling($Calc)
         if($Calc -ge 1024){
             $Calc = $Calc / 1024
+            $Calc = [Math]::Ceiling($Calc)
             $size = "GB"
         }
         $size = $Calc.tostring() + $size
         writeToFile -file $outputFile -path $folderLocation -str " > Security maximum log file is $size"
         if($securityLogMaxSize.MaxSize -lt 196608){
             writeToFile -file $outputFile -path $folderLocation -str " > Security maximum log file size is smaller then the recommendation (196608KB) - this is a potential finding, if logs are not collected to a central location."
-            addToCSV -category "Machine Hardening - Audit" -checkName "Security events maximum log file size" -checkID "machine_SecMaxLog" -problem $true -comment "Security maximum log file size is:$size this is smaller then the recommendation (196608KB)"
+            addToCSV -category "Machine Hardening - Audit" -checkName "Security events maximum log file size" -checkID "machine_SecMaxLog" -problem $true -comment "Security maximum log file size is:$size this is smaller then the recommendation (196608KB)."
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > Security maximum log file size is equal or larger then 196608KB - this is good."
-            addToCSV -category "Machine Hardening - Audit" -checkName "Security events maximum log file size" -checkID "machine_SecMaxLog" -problem $false -comment "System maximum log file size is:$size this is equal or larger then (196608KB)"
+            addToCSV -category "Machine Hardening - Audit" -checkName "Security events maximum log file size" -checkID "machine_SecMaxLog" -problem $false -comment "System maximum log file size is:$size this is equal or larger then (196608KB)."
         }
     }
     else{
         writeToFile -file $outputFile -path $folderLocation -str " > Security maximum log file is not configured, the default is 1MB - this is a potential finding, if logs are not collected to a central location."
-        addToCSV -category "Machine Hardening - Audit" -checkName "Security events maximum log file size" -checkID "machine_SecMaxLog" -problem $true -comment "Security maximum log file is not configured, the default is 1MB"
+        addToCSV -category "Machine Hardening - Audit" -checkName "Security events maximum log file size" -checkID "machine_SecMaxLog" -problem $true -comment "Security maximum log file is not configured, the default is 1MB."
     }
 
     writeToFile -file $outputFile -path $folderLocation -str "`r`n--- Setup ---"
@@ -2236,19 +2246,21 @@ function checkLogSize {
         if($setupLogging.Enable -eq 1){
             $size = "MB"
             $Calc = [double]::Parse($setupLogMaxSize.MaxSize) / 1024
+            $Calc = [Math]::Ceiling($Calc)
             if($Calc -ge 1024){
                 $Calc = $Calc / 1024
+                $Calc = [Math]::Ceiling($Calc)
                 $size = "GB"
             }
             $size = [String]::Parse($Calc) + $size
             writeToFile -file $outputFile -path $folderLocation -str " > Setup maximum log file is $size"
             if($setupLogMaxSize.MaxSize -lt 32768){
                 writeToFile -file $outputFile -path $folderLocation -str " > Setup maximum log file size is smaller then the recommendation (32768KB) - this is a potential finding, if logs are not collected to a central location."
-                addToCSV -category "Machine Hardening - Audit" -checkName "Setup events maximum log file size" -checkID "machine_SetupMaxLog" -problem $true -comment "Setup maximum log file size is:$size and smaller then the recommendation (32768KB)"
+                addToCSV -category "Machine Hardening - Audit" -checkName "Setup events maximum log file size" -checkID "machine_SetupMaxLog" -problem $true -comment "Setup maximum log file size is:$size and smaller then the recommendation (32768KB)."
             }
             else{
                 writeToFile -file $outputFile -path $folderLocation -str " > Setup maximum log file size is equal or larger then 32768KB - this is good."
-                addToCSV -category "Machine Hardening - Audit" -checkName "Setup events maximum log file size" -checkID "machine_SetupMaxLog" -problem $false -comment "Setup maximum log file size is:$size and equal or larger then (32768KB)"
+                addToCSV -category "Machine Hardening - Audit" -checkName "Setup events maximum log file size" -checkID "machine_SetupMaxLog" -problem $false -comment "Setup maximum log file size is:$size and equal or larger then (32768KB)."
 
             }
         }
@@ -2259,7 +2271,7 @@ function checkLogSize {
     }
     else{
         writeToFile -file $outputFile -path $folderLocation -str " > Setup maximum log file is not configured or enabled."
-        addToCSV -category "Machine Hardening - Audit" -checkName "Setup events maximum log file size" -checkID "machine_SetupMaxLog" -comment "Setup maximum log file is not configured or enabled"
+        addToCSV -category "Machine Hardening - Audit" -checkName "Setup events maximum log file size" -checkID "machine_SetupMaxLog" -comment "Setup maximum log file is not configured or enabled."
     }
 
 }
@@ -2277,18 +2289,18 @@ function checkSafeModeAcc4NonAdmin {
     $reg = getRegValue -HKLM $true -regPath "SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" -regName "SafeModeBlockNonAdmins"
     if($null -eq $reg){
         writeToFile -file $outputFile -path $folderLocation -str " > No hardening on Safe mode access by non admins - may be considered a finding if you feel pedant today."
-        addToCSV -category "Machine Hardening - Operation system" -checkName "safe mode access by non-admins" -checkID "machine_SafeModeAcc4NonAdmin" -problem $true -comment "No hardening on Safe mode access by non admins."
+        addToCSV -category "Machine Hardening - Operation system" -checkName "Safe mode access by non-admins" -checkID "machine_SafeModeAcc4NonAdmin" -problem $true -comment "No hardening on Safe mode access by non admins."
 
     }
     else{
         if($reg.SafeModeBlockNonAdmins -eq 1){
             writeToFile -file $outputFile -path $folderLocation -str " > Block Safe mode access by non-admins is enabled - this is a good thing."
-            addToCSV -category "Machine Hardening - Operation system" -checkName "safe mode access by non-admins" -checkID "machine_SafeModeAcc4NonAdmin" -problem $false -comment "Block Safe mode access by non-admins is enabled"
+            addToCSV -category "Machine Hardening - Operation system" -checkName "Safe mode access by non-admins" -checkID "machine_SafeModeAcc4NonAdmin" -problem $false -comment "Block Safe mode access by non-admins is enabled."
 
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > Block Safe mode access by non-admins is disabled - may be considered a finding if you feel pedant today."
-            addToCSV -category "Machine Hardening - Operation system" -checkName "safe mode access by non-admins" -checkID "machine_SafeModeAcc4NonAdmin" -problem $true -comment "Block Safe mode access by non-admins is disabled"
+            addToCSV -category "Machine Hardening - Operation system" -checkName "Safe mode access by non-admins" -checkID "machine_SafeModeAcc4NonAdmin" -problem $true -comment "Block Safe mode access by non-admins is disabled."
         }
     }
 }
@@ -2304,17 +2316,20 @@ function checkProxyConfiguration {
     $reg = getRegValue -HKLM $true -regPath "Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings" -regName "ProxySettingsPerUser"
     if($null -ne $reg -and $reg.ProxySettingsPerUser -eq 0){
         writeToFile -file $outputFile -path $folderLocation -str " > Proxy is configured on the machine (enforced on all users forced by GPO)"
-        #addToCSV -category "Machine Hardening - Networking" -checkName "Proxy configuration" -checkID "machine_proxyConf" -problem $false -comment "Proxy is configured on the machine (enforced on all users forced by GPO)"
+        addToCSV -category "Machine Hardening - Networking" -checkName "Proxy configuration location" -checkID "machine_proxyConf" -problem $false -comment "Proxy is configured on the machine (enforced on all users forced by GPO)."
+    }
+    else{
+        addToCSV -category "Machine Hardening - Networking" -checkName "Proxy configuration location" -checkID "machine_proxyConf" -problem $false -comment "Proxy is configured on the user."
     }
     if (($winVersion.Major -ge 7) -or ($winVersion.Minor -ge 2)){
         $reg = getRegValue -HKLM $true -regPath "SOFTWARE\Policies\Microsoft\Windows\NetworkIsolation" -regName "DProxiesAuthoritive"
         if($null -ne $reg -and $reg.DProxiesAuthoritive -eq 1){
             writeToFile -file $outputFile -path $folderLocation -str " > Windows Network Isolation's automatic proxy discovery is disabled."
-            addToCSV -category "Machine Hardening - Networking" -checkName "Network Isolation's automatic proxy discovery" -checkID "machine_autoIsoProxyDiscovery" -problem $false -comment "Windows Network Isolation's automatic proxy discovery is disabled"
+            addToCSV -category "Machine Hardening - Networking" -checkName "Network Isolation's automatic proxy discovery" -checkID "machine_autoIsoProxyDiscovery" -problem $false -comment "Windows Network Isolation's automatic proxy discovery is disabled."
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > Windows Network Isolation's automatic proxy discovery is enabled! "
-            addToCSV -category "Machine Hardening - Networking" -checkName "Network Isolation's automatic proxy discovery" -checkID "machine_autoIsoProxyDiscovery" -problem $true -comment "Windows Network Isolation's automatic proxy discovery is enabled"
+            addToCSV -category "Machine Hardening - Networking" -checkName "Network Isolation's automatic proxy discovery" -checkID "machine_autoIsoProxyDiscovery" -problem $true -comment "Windows Network Isolation's automatic proxy discovery is enabled."
         }
     }
     writeToFile -file $outputFile -path $folderLocation -str "=== Internet Explorer Settings (System-default) ==="
@@ -2322,25 +2337,25 @@ function checkProxyConfiguration {
     $reg2 = getRegValue -HKLM $false -regPath "Software\Policies\Microsoft\Internet Explorer\Control Panel" -regName "Proxy"
     if($null -ne $reg -and $reg.Proxy -eq 1){
         writeToFile -file $outputFile -path $folderLocation -str " > All users cannot change proxy setting - prevention is on the computer level (only in windows other application not always use the system setting)"
-        addToCSV -category "Machine Hardening - Networking" -checkName "Access to configure proxy" -checkID "machine_accConfProxy" -problem $false -comment "All users cannot change proxy setting"
+        addToCSV -category "Machine Hardening - Networking" -checkName "Access to configure proxy" -checkID "machine_accConfProxy" -problem $false -comment "All users cannot change proxy setting."
     }
     elseif($null -ne $reg2 -and $reg2.Proxy -eq 1){
         writeToFile -file $outputFile -path $folderLocation -str " > User cannot change proxy setting - prevention is on the user level (only in windows other application not always use the system setting)"
-        addToCSV -category "Machine Hardening - Networking" -checkName "Access to configure proxy" -checkID "machine_accConfProxy" -problem "UNKNOWN" -comment "user cannot change proxy setting - Other users might have the ability to change this setting"
+        addToCSV -category "Machine Hardening - Networking" -checkName "Access to configure proxy" -checkID "machine_accConfProxy" -problem "UNKNOWN" -comment "User cannot change proxy setting - Other users might have the ability to change this setting."
     }
     else {
         writeToFile -file $outputFile -path $folderLocation -str " > User can change proxy setting (only in windows other application not always use the system setting)"
-        addToCSV -category "Machine Hardening - Networking" -checkName "Access to configure proxy" -checkID "machine_accConfProxy" -problem $true -comment "User can change proxy setting"
+        addToCSV -category "Machine Hardening - Networking" -checkName "Access to configure proxy" -checkID "machine_accConfProxy" -problem $true -comment "User can change proxy setting."
     }
 
     $reg = getRegValue -HKLM $true -regPath "Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings" -regName "EnableAutoProxyResultCache"
     if($null -ne $reg -and $reg.EnableAutoProxyResultCache -eq 0){
         writeToFile -file $outputFile -path $folderLocation -str " > Caching of Auto-Proxy scripts is Disable (WPAD Disabled)" # need to check
-        addToCSV -category "Machine Hardening - Networking" -checkName "Caching of Auto-Proxy scripts(WPAD)" -checkID "machine_AutoProxyResultCache" -problem $false -comment "Caching of Auto-Proxy scripts is Disable (WPAD disabled)"
+        addToCSV -category "Machine Hardening - Networking" -checkName "Caching of Auto-Proxy scripts(WPAD)" -checkID "machine_AutoProxyResultCache" -problem $false -comment "Caching of Auto-Proxy scripts is Disable (WPAD disabled)."
     }
     else{
         writeToFile -file $outputFile -path $folderLocation -str " > Caching of Auto-Proxy scripts is enabled (WPAD enabled)" # need to check
-        addToCSV -category "Machine Hardening - Networking" -checkName "Caching of Auto-Proxy scripts(WPAD)" -checkID "machine_AutoProxyResultCache" -problem $false -comment "Caching of Auto-Proxy scripts is enabled (WPAD enabled)"
+        addToCSV -category "Machine Hardening - Networking" -checkName "Caching of Auto-Proxy scripts(WPAD)" -checkID "machine_AutoProxyResultCache" -problem $false -comment "Caching of Auto-Proxy scripts is enabled (WPAD enabled)."
     }
     writeToFile -file $outputFile -path $folderLocation -str "`r`n=== WinHTTP service (Auto Proxy) ==="
     $proxySrv = Get-Service -Name "WinHttpAutoProxySvc" -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
@@ -2353,12 +2368,12 @@ function checkProxyConfiguration {
         }
         if($proxySrv.StartType -eq "Disable"){
             writeToFile -file $outputFile -path $folderLocation -str " > WPAD service start type is disabled - WinHTTP Web Proxy Auto-Discovery Service"
-            addToCSV -category "Machine Hardening - Networking" -checkName "WPAD service" -checkID "machine_WPADSvc" -problem $false -comment "WPAD service start type is disabled (WinHTTP Web Proxy Auto-Discovery)"
+            addToCSV -category "Machine Hardening - Networking" -checkName "WPAD service" -checkID "machine_WPADSvc" -problem $false -comment "WPAD service start type is disabled (WinHTTP Web Proxy Auto-Discovery)."
 
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str (" > WPAD service start type is "+$proxySrv.StartType+ " - WinHTTP Web Proxy Auto-Discovery Service")
-            addToCSV -category "Machine Hardening - Networking" -checkName "WPAD service" -checkID "machine_WPADSvc" -problem $true -comment ("WPAD service start type is "+$proxySrv.StartType+ " - WinHTTP Web Proxy Auto-Discovery Service")
+            addToCSV -category "Machine Hardening - Networking" -checkName "WPAD service" -checkID "machine_WPADSvc" -problem $true -comment ("WPAD service start type is "+$proxySrv.StartType+ " - WinHTTP Web Proxy Auto-Discovery Service.")
         }
         writeToFile -file $outputFile -path $folderLocation -str "`r`n=== Raw data:"
         writeToFile -file $outputFile -path $folderLocation -str ($proxySrv | Format-Table -Property Name, DisplayName,Status,StartType,ServiceType| Out-String)
@@ -2374,11 +2389,11 @@ function checkProxyConfiguration {
     $reg = getRegValue -HKLM $false -regPath "Software\Microsoft\Windows\CurrentVersion\Internet Settings" -regName "ProxyEnable"
     if($null -ne $reg -and $reg.ProxyEnable -eq 1){
         writeToFile -file $outputFile -path $folderLocation -str ($userProxy | Out-String)
-        addToCSV -category "Machine Hardening - Networking" -checkName "Proxy settings" -checkID "machine_proxySet" -problem "UNKNOWN" -comment ($userProxy | Out-String)
+        addToCSV -category "Machine Hardening - Networking" -checkName "Proxy settings" -checkID "machine_proxySet" -problem "UNKNOWN" -comment (($userProxy | Out-String)+".")
     }
     else {
         writeToFile -file $outputFile -path $folderLocation -str " > User proxy is disabled"
-        addToCSV -category "Machine Hardening - Networking" -checkName "Proxy settings" -checkID "machine_proxySet" -problem $false -comment "User proxy is disabled"
+        addToCSV -category "Machine Hardening - Networking" -checkName "Proxy settings" -checkID "machine_proxySet" -problem $false -comment "User proxy is disabled."
     }
 
     <# Browser specific tests need to work on it
@@ -2450,22 +2465,22 @@ function checkWinUpdateConfig{
     $reg = getRegValue -HKLM $true -regPath "Software\Policies\Microsoft\Windows\WindowsUpdate\AU" -regName "NoAutoUpdate"
     if($null -ne $reg -and $reg.NoAutoUpdate -eq 0){
         writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is disabled - can be considered a finding."
-        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update" -checkID "machine_autoUpdate" -problem $true -comment "Windows automatic update is disabled"
+        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update" -checkID "machine_autoUpdate" -problem $true -comment "Windows automatic update is disabled."
     }
     else{
-        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update" -checkID "machine_autoUpdate" -problem $false -comment "Windows automatic update is enabled"
+        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update" -checkID "machine_autoUpdate" -problem $false -comment "Windows automatic update is enabled."
         writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is enabled."
     }
     $reg = getRegValue -HKLM $true -regPath "Software\Policies\Microsoft\Windows\WindowsUpdate\AU" -regName "AUOptions"
     switch ($reg.AUOptions) {
         2 { 
             writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is configured to notify for download and notify for install - this may be considered a finding (allows users to not update)." 
-            addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem $true -comment "Windows automatic update is configured to notify for download and notify for install"
+            addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem $true -comment "Windows automatic update is configured to notify for download and notify for install."
             
         }
         3 { 
             writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is configured to auto download and notify for install - this depends if this setting if this is set on servers and there is a manual process to update every month. If so it is OK; otherwise it is not recommended."
-            addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "UNKNOWN" -comment "Windows automatic update is configured to auto download and notify for install (if this setting if this is set on servers and there is a manual process to update every month. If so it is OK)"
+            addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "UNKNOWN" -comment "Windows automatic update is configured to auto download and notify for install (if this setting if this is set on servers and there is a manual process to update every month. If so it is OK)."
          }
         4 { 
             writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is configured to auto download and schedule the install - this is a good thing." 
@@ -2474,36 +2489,36 @@ function checkWinUpdateConfig{
                 switch ($reg.ScheduledInstallDay) {
                     0 { 
                         writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is configured to update every day"
-                        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "false" -comment "Windows automatic update is configured to update every day"
+                        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "false" -comment "Windows automatic update is configured to update every day."
                      }
                     1 { 
                         writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is configured to update every Sunday"
-                        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "false" -comment "Windows automatic update is configured to update every Sunday"
+                        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "false" -comment "Windows automatic update is configured to update every Sunday."
                       }
                     2 { 
                         writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is configured to update every Monday" 
-                        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "false" -comment "Windows automatic update is configured to update every Monday"
+                        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "false" -comment "Windows automatic update is configured to update every Monday."
                  }
                     3 { 
                         writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is configured to update every Tuesday"
-                        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "false" -comment "Windows automatic update is configured to update every Tuesday"
+                        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "false" -comment "Windows automatic update is configured to update every Tuesday."
                         
                     }
                     4 { 
                         writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is configured to update every Wednesday"
-                        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "false" -comment "Windows automatic update is configured to update every Wednesday"
+                        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "false" -comment "Windows automatic update is configured to update every Wednesday."
                       }
                     5 { 
                         writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is configured to update every Thursday"
-                        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "false" -comment "Windows automatic update is configured to update every Thursday"
+                        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "false" -comment "Windows automatic update is configured to update every Thursday."
                       }
                     6 { 
                         writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is configured to update every Friday"
-                        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "false" -comment "Windows automatic update is configured to update every Friday"
+                        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "false" -comment "Windows automatic update is configured to update every Friday."
                     }
                     7 { 
                         writeToFile -file $outputFile -path $folderLocation -str " > Windows automatic update is configured to update every Saturday" 
-                        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "false" -comment "Windows automatic update is configured to update every Saturday"
+                        addToCSV -category "Machine Hardening - Patching" -checkName "Windows automatic update schedule" -checkID "machine_autoUpdateSchedule" -problem "false" -comment "Windows automatic update is configured to update every Saturday."
                      }
                     Default { 
                         writeToFile -file $outputFile -path $folderLocation -str " > Windows Automatic update day is not configured"
@@ -2532,7 +2547,7 @@ function checkWinUpdateConfig{
         $reg = getRegValue -HKLM $true -regPath "Software\Policies\Microsoft\Windows\WindowsUpdate" -regName "WUServer"
         if ($null -eq $reg) {
             writeToFile -file $outputFile -path $folderLocation -str " > WSUS configuration found but no server has been configured."
-            addToCSV -category "Machine Hardening - Patching" -checkName "WSUS update" -checkID "machine_wsusUpdate" -problem $true -comment "SUS configuration found but no server has been configured."
+            addToCSV -category "Machine Hardening - Patching" -checkName "WSUS update" -checkID "machine_wsusUpdate" -problem $true -comment "WSUS configuration found but no server has been configured."
         }
         else {
             $test = $reg.WUServer
@@ -2540,7 +2555,7 @@ function checkWinUpdateConfig{
                 writeToFile -file $outputFile -path $folderLocation -str " > WSUS is configured with unencrypted HTTP connection - this configuration may be vulnerable to local privilege escalation and may be considered a finding."
                 writeToFile -file $outputFile -path $folderLocation -str " > For more information, see: https://book.hacktricks.xyz/windows/windows-local-privilege-escalation#wsus"
                 writeToFile -file $outputFile -path $folderLocation -str " > Note that SCCM with Enhanced HTTP configured my be immune to this attack. For more information, see: https://docs.microsoft.com/en-us/mem/configmgr/core/plan-design/hierarchy/enhanced-http"
-                addToCSV -category "Machine Hardening - Patching" -checkName "WSUS update" -checkID "machine_wsusUpdate" -problem $true -comment "WSUS is configured with unencrypted HTTP connection - this configuration may be vulnerable to local privilege escalation"
+                addToCSV -category "Machine Hardening - Patching" -checkName "WSUS update" -checkID "machine_wsusUpdate" -problem $true -comment "WSUS is configured with unencrypted HTTP connection - this configuration may be vulnerable to local privilege escalation."
 
                 $test = $test.Substring(7)
                 if($test.IndexOf("/") -ge 0){
@@ -2549,7 +2564,7 @@ function checkWinUpdateConfig{
             }
             else {
                 writeToFile -file $outputFile -path $folderLocation -str " > WSUS is configured with HTTPS connection - this is the hardened configuration."
-                addToCSV -category "Machine Hardening - Patching" -checkName "WSUS update" -checkID "machine_wsusUpdate" -problem $false -comment "WSUS is configured with HTTPS connection"
+                addToCSV -category "Machine Hardening - Patching" -checkName "WSUS update" -checkID "machine_wsusUpdate" -problem $false -comment "WSUS is configured with HTTPS connection."
                 $test = $test.Substring(8)
                 if($test.IndexOf("/") -ge 0){
                     $test = $test.Substring(0,$test.IndexOf("/"))
@@ -2599,12 +2614,12 @@ function checkUnquotedSePath {
         }
     }
     if ($boolBadPath){
-        addToCSV -category "Vulnerabilities" -checkName "Unquoted path" -checkID "vul_quotedPath" -problem $true -comment ("There are vulnerable services in this machine:"+($badPaths | Out-String))
+        addToCSV -category "Vulnerabilities" -checkName "Unquoted path" -checkID "vul_quotedPath" -problem $true -comment ("There are vulnerable services in this machine:"+($badPaths | Out-String)+".")
         writeToFile -file $outputFile -path $folderLocation -str " > There are vulnerable services in this machine:"
         writeToFile -file $outputFile -path $folderLocation -str  ($badPaths | Out-String)
     }
     else{
-        addToCSV -category "Vulnerabilities" -checkName "Unquoted path" -checkID "vul_quotedPath" -problem $false -comment "No Service found that is vulnerable with Unquoted path "
+        addToCSV -category "Vulnerabilities" -checkName "Unquoted path" -checkID "vul_quotedPath" -problem $false -comment "No Service found that is vulnerable with Unquoted path."
         writeToFile -file $outputFile -path $folderLocation -str " > The check did not find any service that is vulnerable to unquoted path escalation attack. This is good."
     }
 }
@@ -2625,7 +2640,7 @@ function checkSimulEhtrAndWifi {
             switch ($reg.fMinimizeConnections) {
                 0 {
                      writeToFile -file $outputFile -path $folderLocation -str " > Machine is not hardened and allow simultaneous connections" 
-                     addToCSV -category "Machine Hardening - Networking" -checkName "Ethernet Simultaneous connections " -checkID "machine_ethSim" -problem $true -comment "Machine allows simultaneous Ethernet connections"
+                     addToCSV -category "Machine Hardening - Networking" -checkName "Ethernet Simultaneous connections " -checkID "machine_ethSim" -problem $true -comment "Machine allows simultaneous Ethernet connections."
                     }
                 1 { 
                     writeToFile -file $outputFile -path $folderLocation -str " > Any new automatic internet connection is blocked when the computer has at least one active internet connection to a preferred type of network." 
@@ -2641,13 +2656,13 @@ function checkSimulEhtrAndWifi {
                 }
                 Default {
                     writeToFile -file $outputFile -path $folderLocation -str " > Minimize the number of simultaneous connections to the Internet or a Windows Domain is configured with unknown configuration"
-                    addToCSV -category "Machine Hardening - Networking" -checkName "Ethernet Simultaneous connections " -checkID "machine_ethSim" -problem "UNKNOWN" -comment "Machine is configured with unknown configuration"
+                    addToCSV -category "Machine Hardening - Networking" -checkName "Ethernet Simultaneous connections " -checkID "machine_ethSim" -problem "UNKNOWN" -comment "Machine is configured with unknown configuration."
                 }
             }
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > Minimize the number of simultaneous connections to the Internet or a Windows Domain is not configured"
-            addToCSV -category "Machine Hardening - Networking" -checkName "Ethernet Simultaneous connections " -checkID "machine_ethSim" -problem "UNKNOWN" -comment "Machine is missing configuration for simultaneous Ethernet connections (e.g., for servers it is fine to not configure this setting)"
+            addToCSV -category "Machine Hardening - Networking" -checkName "Ethernet Simultaneous connections " -checkID "machine_ethSim" -problem "UNKNOWN" -comment "Machine is missing configuration for simultaneous Ethernet connections (e.g., for servers it is fine to not configure this setting)."
         }
 
         writeToFile -file $outputFile -path $folderLocation -str "`r`n=== checking if GPO Prohibit connection to non-domain networks when connected to domain authenticated network is configured"
@@ -2656,23 +2671,23 @@ function checkSimulEhtrAndWifi {
         if($null -ne $reg){
             if($reg.fBlockNonDomain -eq 1){
                 writeToFile -file $outputFile -path $folderLocation -str " > Machine is hardened and prohibit connection to non-domain networks when connected to domain authenticated network"
-                addToCSV -category "Machine Hardening - Networking" -checkName "Prohibit connection to non-domain networks" -checkID "machine_PCTNDNetwork" -problem $false -comment "Machine is configured to prohibit connections to non-domain networks when connected to domain authenticated network"
+                addToCSV -category "Machine Hardening - Networking" -checkName "Prohibit connection to non-domain networks" -checkID "machine_PCTNDNetwork" -problem $false -comment "Machine is configured to prohibit connections to non-domain networks when connected to domain authenticated network."
             }
             else{
                 writeToFile -file $outputFile -path $folderLocation -str " > Machine allows connection to non-domain networks when connected to domain authenticated network"
-                addToCSV -category "Machine Hardening - Networking" -checkName "Prohibit connection to non-domain networks" -checkID "machine_PCTNDNetwork" -problem $true -comment "Machine is configured to allow connections to non-domain networks when connected to domain authenticated network"
+                addToCSV -category "Machine Hardening - Networking" -checkName "Prohibit connection to non-domain networks" -checkID "machine_PCTNDNetwork" -problem $true -comment "Machine is configured to allow connections to non-domain networks when connected to domain authenticated network."
             }
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > No configuration found to restrict machine connection to non-domain networks when connected to domain authenticated network"
-            addToCSV -category "Machine Hardening - Networking" -checkName "Prohibit connection to non-domain networks" -checkID "machine_PCTNDNetwork" -problem "UNKNOWN" -comment "No configuration found to restrict machine connection to non-domain networks(e.g., for servers it is fine to not configure this setting)"
+            addToCSV -category "Machine Hardening - Networking" -checkName "Prohibit connection to non-domain networks" -checkID "machine_PCTNDNetwork" -problem "UNKNOWN" -comment "No configuration found to restrict machine connection to non-domain networks(e.g., for servers it is fine to not configure this setting)."
         }
       
     }
     else{
         writeToFile -file $outputFile -path $folderLocation -str " > OS is obsolete and those not support network access restriction based on GPO"
         addToCSV -category "Machine Hardening - Networking" -checkName "Ethernet Simultaneous connections " -checkID "machine_ethSim" -problem "UNKNOWN" -comment "OS is obsolete and those not support network access restriction based on GPO"
-        addToCSV -category "Machine Hardening - Networking" -checkName "Prohibit connection to non-domain networks" -checkID "machine_PCTNDNetwork" -problem "UNKNOWN" -comment "OS is obsolete and those not support network access restriction based on GPO"
+        addToCSV -category "Machine Hardening - Networking" -checkName "Prohibit connection to non-domain networks" -checkID "machine_PCTNDNetwork" -problem "UNKNOWN" -comment "OS is obsolete and those not support network access restriction based on GPO."
     }
     
 }
@@ -2720,7 +2735,7 @@ function checkMacroAndDDE{
                 }
                 else{
                     writeToFile -file $outputFile -path $folderLocation -str " > Excel no configuration found for DDE in this version."
-                    addToCSV -category "Machine Hardening - Software" -checkName "Excel WorkbookLinkWarnings (DDE)" -checkID "machine_excelDDE" -problem "UNKNOWN" -comment "Excel WorkbookLinkWarnings (DDE) hardening is not configured.(might be managed by other mechanism)"
+                    addToCSV -category "Machine Hardening - Software" -checkName "Excel WorkbookLinkWarnings (DDE)" -checkID "machine_excelDDE" -problem "UNKNOWN" -comment "Excel WorkbookLinkWarnings (DDE) hardening is not configured.(might be managed by other mechanism)."
                 }
             }
             else{
@@ -2742,7 +2757,7 @@ function checkMacroAndDDE{
                 }
                 else {
                     writeToFile -file $outputFile -path $folderLocation -str " > Outlook no configuration found for DDE in this version"
-                    addToCSV -category "Machine Hardening - Software" -checkName "Outlook update links (DDE)" -checkID "machine_outlookDDE" -problem "UNKNOWN" -comment "Outlook update links (DDE) hardening is not configured.(might be managed by other mechanism)"
+                    addToCSV -category "Machine Hardening - Software" -checkName "Outlook update links (DDE)" -checkID "machine_outlookDDE" -problem "UNKNOWN" -comment "Outlook update links (DDE) hardening is not configured.(might be managed by other mechanism)."
                 }
 
                 #Word
@@ -2750,16 +2765,16 @@ function checkMacroAndDDE{
                 if($null -ne $reg){
                     if($reg.DontUpdateLinks -eq 1){
                         writeToFile -file $outputFile -path $folderLocation -str " > Word update links (DDE) is disabled."
-                        addToCSV -category "Machine Hardening - Software" -checkName "Word update links (DDE)" -checkID "machine_wordDDE" -problem $true -comment "word update links (DDE) is disabled."
+                        addToCSV -category "Machine Hardening - Software" -checkName "Word update links (DDE)" -checkID "machine_wordDDE" -problem $true -comment "Word update links (DDE) is disabled."
                     }
                     else{
                         writeToFile -file $outputFile -path $folderLocation -str " > Word update links (DDE) is enabled."
-                        addToCSV -category "Machine Hardening - Software" -checkName "Word update links (DDE)" -checkID "machine_wordDDE" -problem $false -comment "word update links (DDE) is enabled."
+                        addToCSV -category "Machine Hardening - Software" -checkName "Word update links (DDE)" -checkID "machine_wordDDE" -problem $false -comment "Word update links (DDE) is enabled."
                     }
                 }
                 else {
                     writeToFile -file $outputFile -path $folderLocation -str " > Word no configuration found for DDE in this version"
-                    addToCSV -category "Machine Hardening - Software" -checkName "Word update links (DDE)" -checkID "machine_wordDDE" -problem "UNKNOWN" -comment "Word update links (DDE) hardening is not configured.(might be managed by other mechanism)"
+                    addToCSV -category "Machine Hardening - Software" -checkName "Word update links (DDE)" -checkID "machine_wordDDE" -problem "UNKNOWN" -comment "Word update links (DDE) hardening is not configured.(might be managed by other mechanism)."
                 }
 
             }
@@ -2822,48 +2837,48 @@ function checkKerberos{
             switch ($reg.supportedencryptiontypes) {
                 8 { 
                     writeToFile -file $outputFile -path $folderLocation -str " > Kerberos encryption allows AES128 only - this is a good thing" 
-                    addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $false -comment "Kerberos encryption allows AES128 only"
+                    addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $false -comment "Kerberos encryption allows AES128 only."
                 }
                 16 { 
                     writeToFile -file $outputFile -path $folderLocation -str " > Kerberos encryption allows AES256 only - this is a good thing"
-                    addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $false -comment "Kerberos encryption allows AES256 only"
+                    addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $false -comment "Kerberos encryption allows AES256 only."
                 }
                 24 { 
                     writeToFile -file $outputFile -path $folderLocation -str " > Kerberos encryption allows AES128 + AES256 only - this is a good thing"
-                    addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $false -comment "Kerberos encryption allows AES128 + AES256 only"
+                    addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $false -comment "Kerberos encryption allows AES128 + AES256 only."
                 }
                 2147483624 { 
                     writeToFile -file $outputFile -path $folderLocation -str " > Kerberos encryption allows AES128 + Future encryption types  only - this is a good thing"
-                    addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $false -comment "Kerberos encryption allows AES128 + Future encryption types"
+                    addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $false -comment "Kerberos encryption allows AES128 + Future encryption types."
                  }
                 2147483632 { 
                     writeToFile -file $outputFile -path $folderLocation -str " > Kerberos encryption allows AES256 + Future encryption types  only - this is a good thing"
-                    addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $false -comment "Kerberos encryption allows AES256 + Future encryption types"
+                    addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $false -comment "Kerberos encryption allows AES256 + Future encryption types."
                  }
                 2147483640 { 
                     writeToFile -file $outputFile -path $folderLocation -str " > Kerberos encryption allows AES128 + AES256 + Future encryption types only - this is a good thing"
-                    addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $false -comment "Kerberos encryption allows AES128 + AES256 + Future encryption types"
+                    addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $false -comment "Kerberos encryption allows AES128 + AES256 + Future encryption types."
                  }
                 2147483616 { 
                     writeToFile -file $outputFile -path $folderLocation -str " > Kerberos encryption allows Future encryption types only - things will not work properly inside the domain (probably)"
-                    addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $true -comment "Kerberos encryption allows Future encryption types only (e.g., dose not allow any encryption"
+                    addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $true -comment "Kerberos encryption allows Future encryption types only (e.g., dose not allow any encryption."
                 }
 
                 0 { 
                     writeToFile -file $outputFile -path $folderLocation -str " > Kerberos encryption allows Default authentication (RC4 and up) - this is a finding"
-                    addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $true -comment "Kerberos encryption allows Default authentication (RC4 and up)"
+                    addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $true -comment "Kerberos encryption allows Default authentication (RC4 and up)."
                  }
                 Default {
                     if($reg.supportedencryptiontypes -ge 2147483616){
                         $temp = $reg.supportedencryptiontypes - 2147483616
                         writeToFile -file $outputFile -path $folderLocation -str " > Kerberos encryption allows low encryption the Decimal Value is: $temp and it is including also Future encryption types (subtracted from the number) - this is a finding"
-                        addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $true -comment "Kerberos encryption allows low encryption the Decimal Value is: $temp and it is including also Future encryption types (subtracted from the number)"
+                        addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $true -comment "Kerberos encryption allows low encryption the Decimal Value is: $temp and it is including also Future encryption types (subtracted from the number)."
 
                     }
                     else
                     {
                         writeToFile -file $outputFile -path $folderLocation -str " > Kerberos encryption allows low encryption the Decimal Value is:"+ $reg.supportedencryptiontypes +" - this is a finding"
-                        addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $true -comment "Kerberos encryption allows low encryption the Decimal Value is: $temp"
+                        addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $true -comment "Kerberos encryption allows low encryption the Decimal Value is: $temp."
                     }
                     writeToFile -file $outputFile -path $folderLocation -str " > For more information: https://techcommunity.microsoft.com/t5/core-infrastructure-and-security/decrypting-the-selection-of-supported-kerberos-encryption-types/ba-p/1628797"
                 }
@@ -2871,7 +2886,7 @@ function checkKerberos{
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > Kerberos encryption allows Default authentication (RC4 and up) - this is a finding"
-            addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $true -comment "Kerberos encryption allows Default authentication (RC4 and up)"
+            addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -problem $true -comment "Kerberos encryption allows Default authentication (RC4 and up)."
         }
         <# Additional check might be added in the future 
         $kerbPath =  "HKLM:\SYSTEM\CurrentControlSet\Control\Lsa\Kerberos\Parameters"
@@ -2908,14 +2923,14 @@ function checkKerberos{
             writeToFile -file $outputFile -path $folderLocation -str " > Kerberos max packet size is not configured or set to 0 (e.g., not using UDP at all) - this is a ok"
         }
         else{
-            writeToFile -file $outputFile -path $folderLocation -str " > erberos max packet size is set to " + $reg.MaxPacketSize + " - this is a finding!"
+            writeToFile -file $outputFile -path $folderLocation -str " > Kerberos max packet size is set to " + $reg.MaxPacketSize + " - this is a finding!"
         }
         #>
         
     }
     else{
         writeToLog -str "Kerberos security check skipped machine is not part of a domain"
-        addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -comment "Machine is not part of a domain"
+        addToCSV -category "Domain Hardening - Authentication" -checkName "Kerberos supported encryption" -checkID "domain_kerbSupEnc" -comment "Machine is not part of a domain."
     }
 }
 
@@ -2925,6 +2940,7 @@ $hostname = hostname
 $partOfDomain = (Get-WmiObject -Class Win32_ComputerSystem).PartOfDomain
 if($partOfDomain){
     $domainName = ((Get-WmiObject -class Win32_ComputerSystem).Domain)
+    # add is DC check 
     $folderLocation = $hostname+"_"+$domainName
 }
 else{

--- a/WindowsAssessment.ps1
+++ b/WindowsAssessment.ps1
@@ -161,7 +161,7 @@ function addControlsToCSV {
     addToCSV -category "Controls" -checkID  "control_RDPTimeOut" -checkName "RDP timeout" -finding "Ensure RDP timeout for disconnected sessions is configured" -risk $csvR1 -relatedFile "RDP"
     addToCSV -category "Controls" -checkID  "control_AuditPol" -checkName "Audit policy" -finding "Ensure audit policy is sufficient (need admin permission to run)" -risk $csvR1 -relatedFile "Audit-Policy"
     addToCSV -category "Controls" -checkID  "control_LocalUsers" -checkName "Local users" -finding "Ensure local users are all disabled or have their password rotated" -risk $csvR1 -relatedFile "Local-Users, Security-Policy.inf" -comment "Local users and cannot connect over the network: Deny access to this computer from the network "
-    addToCSV -category "Controls" -checkID  "control_CredDel" -checkName "Credential delegation" -finding "Ensure Credential delegation is not configured or disabled (need admin permission to run)" -risk $csvR1 -relatedFile "gpresult" -comment "Administrative Templates > System > Credentials Delegation > Allow delegating default credentials + with NTLM"
+    addToCSV -category "Controls" -checkID  "control_CredDel" -checkName "Credential delegation" -finding "Ensure Credential delegation is not configured or disabled (need admin permission to run)" -risk $csvR1 -relatedFile "GPResult" -comment "Administrative Templates > System > Credentials Delegation > Allow delegating default credentials + with NTLM"
     addToCSV -category "Controls" -checkID  "control_LocalAdminRes" -checkName "Local administrators in Restricted groups" -finding "Ensure local administrators group is configured as a restricted group with fixed members (need admin permission to run)" -risk $csvR1 -relatedFile "Security-Policy.inf" -comment "Restricted Groups"
     addToCSV -category "Controls" -checkID  "control_UAC" -checkName "UAC enforcement " -finding "Ensure UAC is enabled (need admin permission to run)" -risk $csvR1 -relatedFile "Security-Policy.inf" -comment "User Account Control settings"
     addToCSV -category "Controls" -checkID  "control_LocalAV" -checkName "Local Antivirus" -finding "Ensure Antivirus is running and updated, advanced Windows Defender features are utilized" -risk $csvR1 -relatedFile "AntiVirus file"
@@ -176,7 +176,7 @@ function addControlsToCSV {
     addToCSV -category "Controls" -checkID  "control_MalProcSrvSoft" -checkName "Irrelevant/malicious processes/services/software" -finding "Ensure no irrelevant/malicious processes/services/software exists" -risk $csvR1 -relatedFile "Services, Process-list, Software, Netstat"
     addToCSV -category "Controls" -checkID  "control_EventLog" -checkName "Event Log" -finding "Ensure logs are exported to SIEM" -risk $csvR1 -relatedFile "Audit-Policy"
     addToCSV -category "Controls" -checkID  "control_HostFW" -checkName "Host firewall" -finding "Host firewall rules are configured to block/filter inbound (Host Isolation)" -risk $csvR1 -relatedFile "indows-Firewall, Windows-Firewall-Rules"
-    addToCSV -category "Controls" -checkID  "control_Macros" -checkName "Macros are restricted" -finding "Ensure office macros are restricted" -risk $csvR1 -relatedFile "gpresult, currently WIP"
+    addToCSV -category "Controls" -checkID  "control_Macros" -checkName "Macros are restricted" -finding "Ensure office macros are restricted" -risk $csvR1 -relatedFile "GPResult, currently WIP"
 }
 
 
@@ -292,7 +292,7 @@ function dataGPO {
             }
             #getting full GPOs folders from sysvol
             writeToLog -str "Function dataGPO: gpresult exporting xml file"
-            $file = getNameForFile -name "gpresult" -extension ".xml"
+            $file = getNameForFile -name $name -extension ".xml"
             $folderName = "Applied GPOs"
             $gpoXMLPath =  $folderLocation+"\"+ $file
             $appliedGPOs = @()
@@ -382,7 +382,7 @@ function dataSecurityPolicy {
     )
     writeToLog -str "running dataSecurityPolicy function"
     # to open the *.inf output file, open MMC, add snap-in "Security Templates", right click and choose new path, choose the *.inf file path, and open it
-    $sPPath = $hostname+"\"+(getNameForFile -name $name -extension ".inf")
+    $sPPath = $folderLocation+"\"+(getNameForFile -name $name -extension ".inf")
     if ($runningAsAdmin)
     {
         writeToScreen -str "Getting security policy settings..." -ForegroundColor Yellow
@@ -3041,7 +3041,7 @@ writeToLog -str ("Script Start Time: " + $startTime.ToString("dd/MM/yyyy HH:mm:s
 dataWhoAmI -name "Whoami"
 
 # get IP settings
-dataIpSettings -name "ipconfig"
+dataIpSettings -name "Ipconfig"
 
 # test proxy settings
 checkProxyConfiguration -name "Internet-Connectivity"
@@ -3053,7 +3053,7 @@ checkInternetAccess -name "Internet-Connectivity"
 getNetCon -name "Netstat"
 
 # get GPOs
-dataGPO -name "gpresult"
+dataGPO -name "GPResult"
 
 # get security policy settings (secpol.msc), run as admin is required
 dataSecurityPolicy -name "Security-Policy"

--- a/WindowsAssessment.ps1
+++ b/WindowsAssessment.ps1
@@ -3,7 +3,7 @@ param ([Switch]$EnableSensitiveInfoSearch = $false)
 
 $Version = "1.34" # used for logging purposes
 ###########################################################
-<# TODO:
+<# TODO: 
 - Output the results to a single file with a simple table - in validation
 - Debug antivirus check (got "registry access is not allowed" exception on Windows 10 without admin elevation)
 - Check for bugs in the SMB1 check - fixed need to check

--- a/WindowsAssessment.ps1
+++ b/WindowsAssessment.ps1
@@ -852,6 +852,12 @@ function checkInternetAccess{
     param (
         $name 
     )
+    if($isServer){
+        $currentRisk = $csvR4
+    }
+    else{
+        $currentRisk = $csvR3
+    }
     $outputFile = getNameForFile -name $name -extension ".txt"
     writeToLog -str "running checkInternetAccess function"    
     writeToScreen -str "Checking if internet access if allowed... " -ForegroundColor Yellow
@@ -868,24 +874,24 @@ function checkInternetAccess{
             writeToFile -file $outputFile -path $folderLocation -str " > DNS request to 8.8.8.8 DNS server was successful. This may be considered a finding, at least on servers."
             writeToFile -file $outputFile -path $folderLocation -str " > DNS request output: "
             writeToFile -file $outputFile -path $folderLocation -str ($test | Out-String)
-            addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - DNS" -checkID "machine_na-dns" -status $csvOp -finding "Public DNS is accessible." -risk $csvR2
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - DNS" -checkID "machine_na-dns" -status $csvOp -finding "Public DNS is accessible." -risk $currentRisk
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > DNS request to 8.8.8.8 DNS server received a timeout. This is generally good - direct access to internet DNS isn't allowed."
-            addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - DNS" -checkID "machine_na-dns" -status $csvSt -finding "Public DNS is not accessible." -risk $csvR2
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - DNS" -checkID "machine_na-dns" -status $csvSt -finding "Public DNS is not accessible." -risk $currentRisk
         }
     }
     else{
         $result = nslookup google.com 8.8.8.8
         if ($result -like "*DNS request timed out*"){
             writeToFile -file $outputFile -path $folderLocation -str " > DNS request to 8.8.8.8 DNS server received a timeout. This is generally good - direct access to internet DNS isn't allowed."
-            addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - DNS" -checkID "machine_na-dns" -status $csvSt -finding "Public DNS is not accessible." -risk $csvR2
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - DNS" -checkID "machine_na-dns" -status $csvSt -finding "Public DNS is not accessible." -risk $currentRisk
         }
         else{
             writeToFile -file $outputFile -path $folderLocation -str " > DNS request to 8.8.8.8 DNS server didn't receive a timeout. This may be considered a finding, at least on servers."
             writeToFile -file $outputFile -path $folderLocation -str " > DNS request output: "
             writeToFile -file $outputFile -path $folderLocation -str ($result | Out-String)
-            addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - DNS" -checkID "machine_na-dns" -status $csvOp -finding "Public DNS is accessible." -risk $csvR2
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - DNS" -checkID "machine_na-dns" -status $csvOp -finding "Public DNS is accessible." -risk $currentRisk
         }
     }
     if($psVer -ge 4){
@@ -992,22 +998,22 @@ function checkInternetAccess{
             $naOutput += "; Port 8080: Blocked"
         }
         if($naStdPorts -and $naNStdPorts){
-            addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -status $csvOp -finding "All ports are open for this machine: $naOutput." -risk $csvR2
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -status $csvOp -finding "All ports are open for this machine: $naOutput." -risk $currentRisk
         }
         elseif ($naStdPorts){
-            addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -status $csvUn -finding "Standard ports (e.g., 80,443) are open for this machine (bad for servers ok for workstations): $naOutput." -risk $csvR2
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -status $csvUn -finding "Standard ports (e.g., 80,443) are open for this machine (bad for servers ok for workstations): $naOutput." -risk $currentRisk
         }
         elseif ($naNStdPorts){
-            addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -status $csvOp -finding "None standard ports are open (maybe miss configuration?) for this machine (bad for servers ok for workstations): $naOutput." -risk $csvR2
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -status $csvOp -finding "None standard ports are open (maybe miss configuration?) for this machine (bad for servers ok for workstations): $naOutput." -risk $currentRisk
         }
         else{
-            addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -status $csvSt -finding "All browsing ports seem to be closed: $naOutput." -risk $csvR2
+            addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -status $csvSt -finding "All browsing ports seem to be closed: $naOutput." -risk $currentRisk
         }
     }
     else{
         writeToFile -file $outputFile -path $folderLocation -str "PowerShell is lower then version 4. Other checks are not supported."
         writeToLog -str "Function checkInternetAccess: PowerShell executing the script does not support curl command. Skipping network connection test."
-        addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -status $csvUn -finding "PowerShell executing the script does not support curl command. (e.g., PSv3 and below)." -risk $csvR2
+        addToCSV -relatedFile $outputFile -category "Machine Hardening - Network Access" -checkName "Network Access - Browsing" -checkID "machine_na-browsing" -status $csvUn -finding "PowerShell executing the script does not support curl command. (e.g., PSv3 and below)." -risk $currentRisk
     }
     <#
     # very long test - skipping it for now 
@@ -1811,35 +1817,37 @@ function checkNTLMv2 {
             writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level Unknown) LM and NTLMv1 restriction does not exist - using OS default. On Windows 2008/7 and above, default is to send NTLMv2 only (Level 3), which is quite secure. `r`n" #using system default depends on OS version
             addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -status $csvSt -finding "NTLM Authentication setting: (Level Unknown) LM and NTLMv1 restriction does not exist - using OS default. On Windows 2008/7 and above, default is to send NTLMv2 only (Level 3)." -risk $csvR4
         }
-        switch ($temp.lmcompatibilitylevel) {
-            (0) { 
-                writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 0) Send LM and NTLM response; never use NTLM 2 session security. Clients use LM and NTLM authentication, and never use NTLM 2 session security; domain controllers accept LM, NTLM, and NTLM 2 authentication. - this is a finding!`r`n"
-                addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -status $csvOp -finding "(Level 0) Send LM and NTLM response; never use NTLM 2 session security. Clients use LM and NTLM authentication, and never use NTLM 2 session security." -risk $csvR4
-            }
-            (1) { 
-                writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 1) Use NTLM 2 session security if negotiated. Clients use LM and NTLM authentication, and use NTLM 2 session security if the server supports it; domain controllers accept LM, NTLM, and NTLM 2 authentication. - this is a finding!`r`n"
-                addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -status $csvOp -finding "(Level 1) Use NTLM 2 session security if negotiated. Clients use LM and NTLM authentication, and use NTLM 2 session security if the server supports it." -risk $csvR4
-            }
-            (2) { 
-                writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 2) Send NTLM response only. Clients use only NTLM authentication, and use NTLM 2 session security if the server supports it; domain controllers accept LM, NTLM, and NTLM 2 authentication. - this is a finding!`r`n"
-                addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -status $csvOp -finding "(Level 2) Send NTLM response only. Clients use only NTLM authentication, and use NTLM 2 session security if the server supports it." -risk $csvR4
-            }
-            (3) { 
-                writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 3) Send NTLM 2 response only. Clients use NTLM 2 authentication, and use NTLM 2 session security if the server supports it; domain controllers accept LM, NTLM, and NTLM 2 authentication. - Not a finding if all servers are with the same configuration.`r`n"
-                addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -status $csvSt -finding "(Level 3) Send NTLM 2 response only. Clients use NTLM 2 authentication, and use NTLM 2 session security if the server supports it." -risk $csvR4
-            }
-            (4) { 
-                writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 4) Domain controllers refuse LM responses. Clients use NTLM authentication, and use NTLM 2 session security if the server supports it; domain controllers refuse LM authentication (that is, they accept NTLM and NTLM 2) - Not a finding if all servers are with the same configuration. If this is a DC, it means that LM is not applicable in the domain at all.`r`n"
-                addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -status $csvSt -finding "(Level 4) Domain controllers refuse LM responses. Clients use NTLM authentication, and use NTLM 2 session security if the server supports it." -risk $csvR4
-            }
-            (5) { 
-                writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 5) Domain controllers refuse LM and NTLM responses (accept only NTLM 2). Clients use NTLM 2 authentication, use NTLM 2 session security if the server supports it; domain controllers refuse NTLM and LM authentication (they accept only NTLM 2 - This is the most hardened configuration. If this is a DC, it means that NTLMv2 and LM are not applicable in the domain at all.)`r`n"
-                addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -status $csvSt -finding "(Level 5) Domain controllers refuse LM and NTLM responses (accept only NTLM 2). Clients use NTLM 2 authentication, use NTLM 2 session security if the server supports it." -risk $csvR4
-            }
-            Default {
-                writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level Unknown) - " + $temp.lmcompatibilitylevel + "`r`n"
-                addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -status $csvUn -finding ("(Level Unknown) - " + $temp.lmcompatibilitylevel +".")  -risk $csvR4
+        else{
+            switch ($temp.lmcompatibilitylevel) {
+                (0) { 
+                    writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 0) Send LM and NTLM response; never use NTLM 2 session security. Clients use LM and NTLM authentication, and never use NTLM 2 session security; domain controllers accept LM, NTLM, and NTLM 2 authentication. - this is a finding!`r`n"
+                    addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -status $csvOp -finding "(Level 0) Send LM and NTLM response; never use NTLM 2 session security. Clients use LM and NTLM authentication, and never use NTLM 2 session security." -risk $csvR4
+                }
+                (1) { 
+                    writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 1) Use NTLM 2 session security if negotiated. Clients use LM and NTLM authentication, and use NTLM 2 session security if the server supports it; domain controllers accept LM, NTLM, and NTLM 2 authentication. - this is a finding!`r`n"
+                    addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -status $csvOp -finding "(Level 1) Use NTLM 2 session security if negotiated. Clients use LM and NTLM authentication, and use NTLM 2 session security if the server supports it." -risk $csvR4
+                }
+                (2) { 
+                    writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 2) Send NTLM response only. Clients use only NTLM authentication, and use NTLM 2 session security if the server supports it; domain controllers accept LM, NTLM, and NTLM 2 authentication. - this is a finding!`r`n"
+                    addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -status $csvOp -finding "(Level 2) Send NTLM response only. Clients use only NTLM authentication, and use NTLM 2 session security if the server supports it." -risk $csvR4
+                }
+                (3) { 
+                    writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 3) Send NTLM 2 response only. Clients use NTLM 2 authentication, and use NTLM 2 session security if the server supports it; domain controllers accept LM, NTLM, and NTLM 2 authentication. - Not a finding if all servers are with the same configuration.`r`n"
+                    addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -status $csvSt -finding "(Level 3) Send NTLM 2 response only. Clients use NTLM 2 authentication, and use NTLM 2 session security if the server supports it." -risk $csvR4
+                }
+                (4) { 
+                    writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 4) Domain controllers refuse LM responses. Clients use NTLM authentication, and use NTLM 2 session security if the server supports it; domain controllers refuse LM authentication (that is, they accept NTLM and NTLM 2) - Not a finding if all servers are with the same configuration. If this is a DC, it means that LM is not applicable in the domain at all.`r`n"
+                    addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -status $csvSt -finding "(Level 4) Domain controllers refuse LM responses. Clients use NTLM authentication, and use NTLM 2 session security if the server supports it." -risk $csvR4
+                }
+                (5) { 
+                    writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level 5) Domain controllers refuse LM and NTLM responses (accept only NTLM 2). Clients use NTLM 2 authentication, use NTLM 2 session security if the server supports it; domain controllers refuse NTLM and LM authentication (they accept only NTLM 2 - This is the most hardened configuration. If this is a DC, it means that NTLMv2 and LM are not applicable in the domain at all.)`r`n"
+                    addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -status $csvSt -finding "(Level 5) Domain controllers refuse LM and NTLM responses (accept only NTLM 2). Clients use NTLM 2 authentication, use NTLM 2 session security if the server supports it." -risk $csvR4
+                }
+                Default {
+                    writeToFile -file $outputFile -path $folderLocation -str " > NTLM Authentication setting: (Level Unknown) - " + $temp.lmcompatibilitylevel + "`r`n"
+                    addToCSV -relatedFile $outputFile -category "Domain Hardening - Authentication" -checkName "NTLM Compatibility level" -checkID "domain_NTLMComLevel" -status $csvUn -finding ("(Level Unknown) :" + $temp.lmcompatibilitylevel +".")  -risk $csvR4
 
+                }
             }
         }
     }
@@ -3008,9 +3016,18 @@ addToCSV -category "Information" -checkName "Script Version" -checkID "info_sVer
 writeToLog -str ("Windows Version: " + (Get-WmiObject -class Win32_OperatingSystem).Caption)
 addToCSV -category "Information" -checkName "Windows Version" -checkID "info_wVer" -status $null -finding ((Get-WmiObject -class Win32_OperatingSystem).Caption) -risk $csvR1
 switch ((Get-WmiObject -Class Win32_OperatingSystem).ProductType){
-    1 {$OSType = "Client"}
-    2 {$OSType = "Domain Controller"}
-    3 {$OSType = "Server"}
+    1 {
+        $OSType = "Client"
+        $isServer = $false
+    }
+    2 {
+        $OSType = "Domain Controller"
+        $isServer = $true
+    }
+    3 {
+        $OSType = "Server"
+        $isServer = $true
+    }
     default: {$OSType = "Unknown"}
 }
 addToCSV -category "Information" -checkName "OS Type" -checkID "info_OSType" -status $null -finding $OSType -risk $csvR1


### PR DESCRIPTION
Version 1.36 has some major updates and changes to the script:
Main feature to be added is a centralized file for all the checks and controls.
The new file is called "Checks.csv", and it contains the following fields:
Category - will help you filter throw the checks as they will most definitely grow in numbers in the near future.
Check name - contains the human readable name of the check or control.
Status - will signify the result of the test.
 - Opportunity - problem that is recommended to be fixed.
 -  Strength - a good thing in the configuration.
 - Unknown - need further validation in the related files.
 - Empty - general information or Control check.
Risk - signifies the risk of the test. (e.g., the higher the risk, the more urgent this problem needs to be fixed) Risks are separated into 5 levels (Information, Low, Medium, High and Critical).
Finding - explaining the test and the problem.
Comment - general information about the test.
Related files - Need to dig dipper? The relevant file where the test has written its output will be in this field.
CheckID - Unique programmatic names for checks and controls.

More things have changed:
1. GPO export now exports the full GPO file that is applied on the machine. (Restricted to 5MB and requires an active connection to the domain)
2. Kerberos supported encryption check - this test will run on every machine, but Domain Controllers. are the ones to decide...
3. Added ipconfig in CSV format.
4. Netstat file is now in CSV format.
5. Added an internal function to test registry values.
6. Changed the folder and zip name to include a domain name or OS name. (Based on if the machine is connected to the domain or not...)
7. Other minor bug fixing has been done.
